### PR TITLE
Use Eidolon API directly

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -120,9 +120,10 @@ dependencies {
 
     minecraft "net.minecraftforge:forge:${minecraft_version}-${forge_version}"
 
-    // Eidolon dependency - temporarily disabled due to mixin compatibility issues
-    implementation fg.deobf("curse.maven:eidolon-repraised-870250:5877358")
-    //implementation ("com.alexthw.eidolon_repraised:eidolon_repraised-${minecraft_version}-${eidolon_version}") {transitive=false}
+    // Eidolon dependency - now a compile-time requirement
+    implementation ("com.alexthw.eidolon_repraised:eidolon-${minecraft_version}:${eidolon_version}") {
+        transitive = false
+    }
 
     // Curios dependencies - following official documentation
     // Compile against only the API artifact

--- a/gradle.properties
+++ b/gradle.properties
@@ -12,7 +12,7 @@ loader_version_range=[47,)
 
 # Mod Dependencies
 curios_version=5.14.1+1.20.1
-eidolon_version=0.3.9.0.8
+eidolon_version=0.3.9.0.9
 
 mapping_channel=official
 


### PR DESCRIPTION
## Summary
- add Eidolon Repraised as compile-time dependency
- replace reflective page, codex, and research integration with direct API calls

## Testing
- `./gradlew build` *(fails: build process did not complete in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68a4a49eb5a48327b52ed86e86b7fc1a