### PR TITLE
Add support for additional Eidolon codex page types

### DIFF
--- a/docs/codex_reference.md
+++ b/docs/codex_reference.md
@@ -40,8 +40,23 @@ Top‑down ritual circle with ingredients and steps.
 ```
 Item lists or material checklists.
 
-### Other recipe pages
-The system also accepts `smelting`, `crucible`, and `workbench` page types for specialized recipes.
+### `smelting`
+```json
+{ "type": "smelting", "input": "minecraft:iron_ore", "result": "minecraft:iron_ingot" }
+```
+Shows a furnace recipe with input and output items.
+
+### `workbench`
+```json
+{ "type": "workbench", "item": "eidolon:wooden_altar" }
+```
+Displays an Eidolon workbench recipe.
+
+### `crucible`
+```json
+{ "type": "crucible", "recipe": "eidolon:arcane_gold_ingot" }
+```
+Specialized recipe page for crucible crafting.
 
 ## Advanced Formatting Codes
 


### PR DESCRIPTION
## Summary
- Support `list`, `smelting`, and `workbench` pages in `EidolonPageConverter`
- Provide helper methods for new page types
- Document JSON examples for smelting, workbench, and crucible pages

## Testing
- `./gradlew test` *(fails: Could not resolve com.alexthw.eidolon_repraised:eidolon-1.20.1:0.3.9.0.9)*


------
https://chatgpt.com/codex/tasks/task_e_68a4bfe088188327b6a99afc17c6367d