### PR TITLE
feat: support custom codex chapters

### DIFF
--- a/docs/DATAPACK_STRUCTURE.md
+++ b/docs/DATAPACK_STRUCTURE.md
@@ -7,6 +7,9 @@ See [Codex Tutorial](codex_tutorial.md) for a guided walkthrough and [Codex Refe
 ```
 📦 data/
 ├── 📁 eidolonunchained/                    # Your mod namespace
+│   ├── 📁 codex_chapters/                  # Optional new chapter definitions
+│   │   └── 📄 mythology.json               # Defines a new chapter
+│   │
 │   ├── 📁 codex_entries/                   # Codex system extensions
 │   │   ├── 📄 void_amulet_advanced.json    # Extends VOID_AMULET chapter
 │   │   ├── 📄 ritual_mastery.json          # Extends SUMMON_RITUAL chapter
@@ -38,7 +41,7 @@ See [Codex Tutorial](codex_tutorial.md) for a guided walkthrough and [Codex Refe
 
 ```json
 {
-  "target_chapter": "CHAPTER_NAME",          // ← Must match Eidolon's field name
+  "target_chapter": "CHAPTER_NAME",          // ← Eidolon field name or custom ID
   "pages": [
     {
       "type": "title",                       // ← Page types: title, text, crafting
@@ -57,6 +60,15 @@ See [Codex Tutorial](codex_tutorial.md) for a guided walkthrough and [Codex Refe
       "text": "Recipe description"
     }
   ]
+}
+```
+
+## 🗂️ **Codex Chapter Template**
+
+```json
+{
+  "title": "yourmod.codex.chapter.mythology",
+  "icon": "minecraft:book"
 }
 ```
 
@@ -91,8 +103,8 @@ See [Codex Tutorial](codex_tutorial.md) for a guided walkthrough and [Codex Refe
 }
 ```
 
-## 🎯 **Available Eidolon Chapters** 
-*(Use these exact names for `target_chapter`)*
+## 🎯 **Available Eidolon Chapters**
+*(Use these exact names for built-in chapters or a namespaced ID for custom ones)*
 
 ### **🏺 Artifacts & Items**
 - `"VOID_AMULET"`        - Void amulet crafting and uses

--- a/docs/codex_reference.md
+++ b/docs/codex_reference.md
@@ -64,6 +64,19 @@ Additional tips:
 - `/eidolonunchained reload_codex` – Reload JSON entries without restarting.
 - `/eidolonunchained test_translations` – Report missing or malformed translation keys.
 
+## Custom Chapters
+
+Define new chapters by adding files under `data/<namespace>/codex_chapters/`:
+
+```json
+{
+  "title": "yourmod.codex.chapter.mythology",
+  "icon": "minecraft:book"
+}
+```
+
+Entries can then target the chapter with `"target_chapter": "yourmod:mythology"`.
+
 ## Troubleshooting
 
 | Problem | Cause | Fix |

--- a/docs/codex_tutorial.md
+++ b/docs/codex_tutorial.md
@@ -53,3 +53,26 @@ assets/
 - Use `/reload` after changing JSON files.
 - Use `/eidolonunchained reload_codex` or restart the game after editing translations.
 - `/eidolonunchained test_translations` prints missing or broken keys for debugging.
+
+## Defining a New Chapter
+
+To create an entirely new chapter instead of extending an existing one:
+
+1. **Create a chapter definition** in `data/yourmod/codex_chapters/`:
+   ```json
+   {
+     "title": "yourmod.codex.chapter.mythology",
+     "icon": "minecraft:book"
+   }
+   ```
+2. **Target the chapter** from a codex entry using its namespaced ID:
+   ```json
+   {
+     "target_chapter": "yourmod:mythology",
+     "pages": [ { "type": "text", "text": "yourmod.codex.chapter.mythology.start" } ]
+   }
+   ```
+3. **Add translations** for the chapter title and pages as usual.
+
+When the datapack is loaded the new chapter will be created with the specified
+title and icon and any entries targeting it will populate its pages.


### PR DESCRIPTION
## Summary
- discover Eidolon chapters via reflection instead of a hard-coded list
- load `codex_chapters` datapack files to register brand new chapters
- document how to declare custom chapters in datapacks

## Testing
- `./gradlew build` *(fails: Could not find com.alexthw.eidolon_repraised:eidolon-1.20.1:0.3.9.0.9)*

------
https://chatgpt.com/codex/tasks/task_e_68a4bfe24d4c8327bbe2c613c13bc689