### PR TITLE
Use fully qualified chapters for codex entries

### DIFF
--- a/src/main/resources/data/eidolonunchained/codex_entries/advanced_monsters.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/advanced_monsters.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "monsters",
+  "target_chapter": "eidolon:monsters",
   "pages": [
     {
       "type": "title",

--- a/src/main/resources/data/eidolonunchained/codex_entries/advanced_summoning.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/advanced_summoning.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "summon_ritual",
+  "target_chapter": "eidolon:summon_ritual",
   "pages": [
     {
       "type": "title", 

--- a/src/main/resources/data/eidolonunchained/codex_entries/artifice/arcane_gold.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/artifice/arcane_gold.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "arcane_gold",
+  "target_chapter": "eidolon:arcane_gold",
   "title": "eidolonunchained.codex.entry.arcane_gold.advanced_techniques.title",
   "description": "eidolonunchained.codex.entry.arcane_gold.advanced_techniques.description",
   "icon": {

--- a/src/main/resources/data/eidolonunchained/codex_entries/artifice/void_amulet.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/artifice/void_amulet.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "void_amulet",
+  "target_chapter": "eidolon:void_amulet",
   "title": "eidolonunchained.codex.entry.void_amulet.mastery.title", 
   "description": "eidolonunchained.codex.entry.void_amulet.mastery.description",
   "icon": {

--- a/src/main/resources/data/eidolonunchained/codex_entries/crystal_rituals.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/crystal_rituals.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "crystal_ritual",
+  "target_chapter": "eidolon:crystal_ritual",
   "pages": [
     {
       "type": "title",

--- a/src/main/resources/data/eidolonunchained/codex_entries/equipment/warded_mail.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/equipment/warded_mail.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "warded_mail",
+  "target_chapter": "eidolon:warded_mail",
   "pages": [
     {
       "type": "text",

--- a/src/main/resources/data/eidolonunchained/codex_entries/nature/monsters_advanced_studies.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/nature/monsters_advanced_studies.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "monsters",
+  "target_chapter": "eidolon:monsters",
   "title": "eidolonunchained.codex.entry.monsters.advanced_studies.title",
   "description": "eidolonunchained.codex.entry.monsters.advanced_studies.description",
   "icon": {

--- a/src/main/resources/data/eidolonunchained/codex_entries/nature/monsters_rare_variants.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/nature/monsters_rare_variants.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "monsters",
+  "target_chapter": "eidolon:monsters",
   "title": "eidolonunchained.codex.entry.monsters.rare_variants.title",
   "description": "eidolonunchained.codex.entry.monsters.rare_variants.description", 
   "icon": {

--- a/src/main/resources/data/eidolonunchained/codex_entries/rare_monsters.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/rare_monsters.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "monsters",
+  "target_chapter": "eidolon:monsters",
   "pages": [
     {
       "type": "title",

--- a/src/main/resources/data/eidolonunchained/codex_entries/rituals/crystal_ritual.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/rituals/crystal_ritual.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "crystal_ritual",
+  "target_chapter": "eidolon:crystal_ritual",
   "title": "eidolonunchained.codex.entry.crystal_ritual.mastery.title",
   "description": "eidolonunchained.codex.entry.crystal_ritual.mastery.description",
   "icon": {

--- a/src/main/resources/data/eidolonunchained/codex_entries/rituals/summon_ritual.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/rituals/summon_ritual.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "summon_ritual",
+  "target_chapter": "eidolon:summon_ritual",
   "title": "eidolonunchained.codex.entry.summon_ritual.advanced_techniques.title",
   "description": "eidolonunchained.codex.entry.summon_ritual.advanced_techniques.description",
   "icon": {

--- a/src/main/resources/data/eidolonunchained/codex_entries/signs/sacred_sign.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/signs/sacred_sign.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "sacred_sign",
+  "target_chapter": "eidolon:sacred_sign",
   "title": "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.title",
   "description": "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.description",
   "icon": {

--- a/src/main/resources/data/eidolonunchained/codex_entries/signs/wicked_sign.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/signs/wicked_sign.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "wicked_sign",
+  "target_chapter": "eidolon:wicked_sign",
   "title": "eidolonunchained.codex.entry.wicked_sign.advanced_applications.title",
   "description": "eidolonunchained.codex.entry.wicked_sign.advanced_applications.description",
   "icon": {

--- a/src/main/resources/data/eidolonunchained/codex_entries/void_mastery.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/void_mastery.json
@@ -1,5 +1,5 @@
 {
-  "chapter": "void_amulet",
+  "target_chapter": "eidolon:void_amulet",
   "pages": [
     {
       "type": "title",


### PR DESCRIPTION
## Summary
- replace `chapter` fields in codex entries with `target_chapter` using `eidolon:<chapter>` identifiers
- ensure references use lowercase, fully qualified resource locations

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a5c194c06083278b2e5f32eaf4d0a7