### PR TITLE
Load datapack research chapters alongside entries

### DIFF
--- a/data/eidolonunchained/research_chapters/alchemy_basics.json
+++ b/data/eidolonunchained/research_chapters/alchemy_basics.json
@@ -1,0 +1,9 @@
+{
+  "id": "eidolonunchained:alchemy_basics",
+  "title": "Alchemy Basics",
+  "description": "Foundational studies in alchemy.",
+  "category": "alchemy",
+  "icon": {
+    "item": "minecraft:glass_bottle"
+  }
+}

--- a/data/eidolonunchained/research_chapters/dark_arts.json
+++ b/data/eidolonunchained/research_chapters/dark_arts.json
@@ -1,0 +1,9 @@
+{
+  "id": "eidolonunchained:dark_arts",
+  "title": "Dark Arts",
+  "description": "Secrets best left untold.",
+  "category": "occult",
+  "icon": {
+    "item": "minecraft:ender_eye"
+  }
+}


### PR DESCRIPTION
## Summary
- Add example research chapter JSONs for alchemy basics and dark arts
- Load chapters and entries from datapacks by scanning both `research_chapters` and `research_entries`
- Separate chapter loading from entry loading in `ResearchDataManager`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a5c19661488327b4bb06c528e3bb57