### PR TITLE
Implement research entry conditional requirements

### DIFF
--- a/docs/RESEARCH_CONDITIONS.md
+++ b/docs/RESEARCH_CONDITIONS.md
@@ -1,0 +1,39 @@
+# Research Condition Types
+
+Eidolon Unchained research entries can specify **conditional_requirements** to gate
+a research until certain world or player states are met. The following condition
+types are supported:
+
+## Dimension
+```json
+"conditional_requirements": {
+  "dimension": "minecraft:the_nether"
+}
+```
+*The player must be in the specified dimension.*
+
+## Time Range
+```json
+"conditional_requirements": {
+  "time_range": { "min": 13000, "max": 23000 }
+}
+```
+*Only valid when the world time (0-24000) is within the range. Wraps around midnight when `min` is greater than `max`.*
+
+## Weather
+```json
+"conditional_requirements": {
+  "weather": "thunder"
+}
+```
+*Valid weather values: `clear`, `rain`, `thunder`. The condition passes when the world's weather matches.*
+
+## Inventory Items
+```json
+"conditional_requirements": {
+  "inventory": [
+    { "item": "eidolon:athame", "count": 1 }
+  ]
+}
+```
+*All listed items must be present in the player's inventory in at least the specified quantity.*

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonResearchIntegration.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonResearchIntegration.java
@@ -3,12 +3,14 @@ package com.bluelotuscoding.eidolonunchained.integration;
 import com.bluelotuscoding.eidolonunchained.data.ResearchDataManager;
 import com.bluelotuscoding.eidolonunchained.research.ResearchChapter;
 import com.bluelotuscoding.eidolonunchained.research.ResearchEntry;
+import com.bluelotuscoding.eidolonunchained.research.conditions.ResearchCondition;
 import com.mojang.logging.LogUtils;
 import elucent.eidolon.api.research.Research;
 import elucent.eidolon.registries.Researches;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.network.chat.Component;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.client.Minecraft;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
 import net.minecraftforge.fml.event.lifecycle.FMLClientSetupEvent;
@@ -63,9 +65,17 @@ public class EidolonResearchIntegration {
                     LOGGER.warn("✗ Missing chapter {} for research {} - skipping", data.getChapter(), researchId);
                     continue;
                 }
-                Research research = createResearchFromEntry(data);
-                Researches.register(research);
-                LOGGER.info("✓ Injected research entry: {}", researchId);
+                boolean conditionsMet = true;
+                if (!data.getConditions().isEmpty()) {
+                    conditionsMet = data.getConditions().stream().allMatch(c -> c.test(Minecraft.getInstance().player));
+                }
+                if (conditionsMet) {
+                    Research research = createResearchFromEntry(data);
+                    Researches.register(research);
+                    LOGGER.info("✓ Injected research entry: {}", researchId);
+                } else {
+                    LOGGER.info("✗ Skipping research entry {} due to unmet conditions", researchId);
+                }
             }
 
             LOGGER.info("Research integration complete!");

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/DimensionCondition.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/DimensionCondition.java
@@ -1,0 +1,25 @@
+package com.bluelotuscoding.eidolonunchained.research.conditions;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Requires the player to be in a specific dimension.
+ */
+public class DimensionCondition implements ResearchCondition {
+    private final ResourceLocation dimension;
+
+    public DimensionCondition(ResourceLocation dimension) {
+        this.dimension = dimension;
+    }
+
+    public ResourceLocation getDimension() {
+        return dimension;
+    }
+
+    @Override
+    public boolean test(Player player) {
+        if (player == null) return true;
+        return player.level().dimension().location().equals(dimension);
+    }
+}

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/InventoryCondition.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/InventoryCondition.java
@@ -1,0 +1,39 @@
+package com.bluelotuscoding.eidolonunchained.research.conditions;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+
+/**
+ * Requires the player to have a certain number of a specific item in their inventory.
+ */
+public class InventoryCondition implements ResearchCondition {
+    private final Item item;
+    private final int count;
+
+    public InventoryCondition(Item item, int count) {
+        this.item = item;
+        this.count = count;
+    }
+
+    public Item getItem() {
+        return item;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean test(Player player) {
+        if (player == null) return true;
+        int found = 0;
+        for (ItemStack stack : player.getInventory().items) {
+            if (stack.is(item)) {
+                found += stack.getCount();
+                if (found >= count) return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/ResearchCondition.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/ResearchCondition.java
@@ -1,0 +1,16 @@
+package com.bluelotuscoding.eidolonunchained.research.conditions;
+
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Base interface for conditional requirements that gate research entries.
+ */
+public interface ResearchCondition {
+    /**
+     * Returns true if the condition is satisfied for the given player.
+     *
+     * @param player the player to test against, may be null when no player context is available
+     * @return true if the condition is met
+     */
+    boolean test(Player player);
+}

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/TimeCondition.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/TimeCondition.java
@@ -1,0 +1,36 @@
+package com.bluelotuscoding.eidolonunchained.research.conditions;
+
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Requires the world time to fall within a specific range.
+ */
+public class TimeCondition implements ResearchCondition {
+    private final long min;
+    private final long max;
+
+    public TimeCondition(long min, long max) {
+        this.min = min;
+        this.max = max;
+    }
+
+    public long getMin() {
+        return min;
+    }
+
+    public long getMax() {
+        return max;
+    }
+
+    @Override
+    public boolean test(Player player) {
+        if (player == null) return true;
+        long time = player.level().getDayTime() % 24000L;
+        if (min <= max) {
+            return time >= min && time <= max;
+        } else {
+            // wrap around midnight
+            return time >= min || time <= max;
+        }
+    }
+}

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/WeatherCondition.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/conditions/WeatherCondition.java
@@ -1,0 +1,39 @@
+package com.bluelotuscoding.eidolonunchained.research.conditions;
+
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+
+/**
+ * Requires a specific weather state.
+ */
+public class WeatherCondition implements ResearchCondition {
+    public enum WeatherType { CLEAR, RAIN, THUNDER }
+
+    private final WeatherType weather;
+
+    public WeatherCondition(String weather) {
+        String w = weather.toLowerCase();
+        if (w.equals("rain") || w.equals("raining")) {
+            this.weather = WeatherType.RAIN;
+        } else if (w.equals("thunder") || w.equals("thunderstorm")) {
+            this.weather = WeatherType.THUNDER;
+        } else {
+            this.weather = WeatherType.CLEAR;
+        }
+    }
+
+    public WeatherType getWeather() {
+        return weather;
+    }
+
+    @Override
+    public boolean test(Player player) {
+        if (player == null) return true;
+        Level level = player.level();
+        return switch (weather) {
+            case CLEAR -> !level.isRaining();
+            case RAIN -> level.isRaining() && !level.isThundering();
+            case THUNDER -> level.isThundering();
+        };
+    }
+}


### PR DESCRIPTION
## Summary
- add `ResearchCondition` interface with dimension, time, weather, and inventory implementations
- extend `ResearchEntry` and loader to parse `conditional_requirements`
- enforce research conditions during injection and at the research table
- document available research condition types

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a5cd1ae31883278a3e848a80705808