### PR TITLE
Ensure ResearchEntry supports conditional requirements

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
@@ -37,6 +37,12 @@ import java.util.Map;
 import java.util.ArrayList;
 import java.util.Set;
 
+import com.bluelotuscoding.eidolonunchained.research.conditions.DimensionCondition;
+import com.bluelotuscoding.eidolonunchained.research.conditions.InventoryCondition;
+import com.bluelotuscoding.eidolonunchained.research.conditions.ResearchCondition;
+import com.bluelotuscoding.eidolonunchained.research.conditions.TimeCondition;
+import com.bluelotuscoding.eidolonunchained.research.conditions.WeatherCondition;
+
 /**
  * Manages loading and registration of custom research entries and chapters from datapacks.
  * This extends Eidolon's research system (separate from the codex system).
@@ -450,7 +456,7 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
             }
 
             ResearchEntry entry = new ResearchEntry(entryId, title, description, chapter, icon,
-                                                    prerequisites, unlocks, x, y, type, additional, tasks);
+                                                    prerequisites, unlocks, x, y, type, additional, tasks, conditions);
 
             LOADED_RESEARCH_ENTRIES.put(entryId, entry);
             RESEARCH_EXTENSIONS.computeIfAbsent(chapter, k -> new ArrayList<>()).add(entry);

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/ResearchEntry.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/ResearchEntry.java
@@ -33,6 +33,7 @@ public class ResearchEntry {
     private final ResearchType type;
     private final JsonObject additionalData;
     private final java.util.Map<Integer, java.util.List<ResearchTask>> tasks;
+    private final List<ResearchCondition> conditions;
 
     public enum ResearchType {
         BASIC("basic"),
@@ -56,7 +57,8 @@ public class ResearchEntry {
                         ResourceLocation chapter, ItemStack icon, List<ResourceLocation> prerequisites,
                         List<ResourceLocation> unlocks, int x, int y, ResearchType type,
                         JsonObject additionalData,
-                        java.util.Map<Integer, java.util.List<ResearchTask>> tasks) {
+                        java.util.Map<Integer, java.util.List<ResearchTask>> tasks,
+                        List<ResearchCondition> conditions) {
         this.id = id;
         this.title = title;
         this.description = description;
@@ -69,7 +71,7 @@ public class ResearchEntry {
         this.type = type;
         this.additionalData = additionalData != null ? additionalData : new JsonObject();
         this.tasks = tasks != null ? tasks : new java.util.HashMap<>();
-
+        this.conditions = conditions != null ? conditions : new ArrayList<>();
     }
 
     // Getters
@@ -85,6 +87,7 @@ public class ResearchEntry {
     public ResearchType getType() { return type; }
     public JsonObject getAdditionalData() { return additionalData; }
     public java.util.Map<Integer, java.util.List<ResearchTask>> getTasks() { return tasks; }
+    public List<ResearchCondition> getConditions() { return conditions; }
 
     /**
      * Converts this research entry to a JSON format for datapack generation
@@ -211,6 +214,7 @@ public class ResearchEntry {
         private ResearchType type = ResearchType.BASIC;
         private JsonObject additionalData = new JsonObject();
         private java.util.Map<Integer, java.util.List<ResearchTask>> tasks = new java.util.HashMap<>();
+        private List<ResearchCondition> conditions = new ArrayList<>();
 
         public Builder(ResourceLocation id) {
             this.id = id;
@@ -268,9 +272,14 @@ public class ResearchEntry {
             return this;
         }
 
+        public Builder condition(ResearchCondition condition) {
+            this.conditions.add(condition);
+            return this;
+        }
+
         public ResearchEntry build() {
             return new ResearchEntry(id, title, description, chapter, icon,
-                                   prerequisites, unlocks, x, y, type, additionalData, tasks);
+                                   prerequisites, unlocks, x, y, type, additionalData, tasks, conditions);
 
         }
     }


### PR DESCRIPTION
## Summary
- Pass parsed conditional requirements into `ResearchEntry` when loading research entries
- Expand `ResearchEntry` to store and expose a list of `ResearchCondition`s
- Allow builder to accumulate and forward conditions to the entry constructor

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a5f2df0b2c8327b846b605da06ae31