### PR TITLE
Add task counterparts for research conditions

### DIFF
--- a/docs/research_entries.md
+++ b/docs/research_entries.md
@@ -13,8 +13,8 @@ This guide explains how to define research entries for Eidolon Unchained. Each e
 | `unlocks` | Research IDs made available after completion. |
 | `type` | Entry category: `basic`, `advanced`, `forbidden`, `ritual`, or `crafting`. |
 | `x`, `y` | Coordinates on the research screen grid. |
-| `conditions` | Optional conditional requirements (dimension, biome, player state, etc.). Implemented via dedicated condition classes. |
-| `tasks` | Objectives the player must complete. Each task uses a specific task class such as `KillEntitiesTask`, `CollectItemsTask`, or `UseRitualTask`. |
+| `conditions` | Deprecated in favour of task‑based equivalents. Older datapacks may still use this section to gate entries by dimension, time or inventory. |
+| `tasks` | Objectives the player must complete. Each task uses a specific task class such as `KillEntitiesTask`, `CollectItemsTask`, `UseRitualTask`, `EnterDimensionTask`, `TimeWindowTask`, `WeatherTask`, or `InventoryTask`. |
 | `rewards` | Extra benefits granted on completion (items, advancements, unlocks). |
 
 ## ⭐ Star Requirements

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
@@ -4,6 +4,7 @@ import com.bluelotuscoding.eidolonunchained.EidolonUnchained;
 import com.bluelotuscoding.eidolonunchained.research.ResearchEntry;
 import com.bluelotuscoding.eidolonunchained.research.ResearchChapter;
 import com.bluelotuscoding.eidolonunchained.research.tasks.*;
+import com.bluelotuscoding.eidolonunchained.research.conditions.*;
 import elucent.eidolon.api.research.ResearchTask;
 import elucent.eidolon.registries.Researches;
 import com.google.gson.Gson;
@@ -388,6 +389,24 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
                                     int count = tobj.has("count") ? tobj.get("count").getAsInt() : 1;
                                     task = new CollectItemsTask(item, count);
                                 }
+                                case ENTER_DIMENSION -> {
+                                    ResourceLocation dim = ResourceLocation.tryParse(tobj.get("dimension").getAsString());
+                                    task = new EnterDimensionTask(dim);
+                                }
+                                case TIME_WINDOW -> {
+                                    long min = tobj.has("min") ? tobj.get("min").getAsLong() : 0;
+                                    long max = tobj.has("max") ? tobj.get("max").getAsLong() : 24000;
+                                    task = new TimeWindowTask(min, max);
+                                }
+                                case WEATHER -> {
+                                    String weather = tobj.get("weather").getAsString();
+                                    task = new WeatherTask(weather);
+                                }
+                                case INVENTORY -> {
+                                    ResourceLocation item = ResourceLocation.tryParse(tobj.get("item").getAsString());
+                                    int count = tobj.has("count") ? tobj.get("count").getAsInt() : 1;
+                                    task = new InventoryTask(item, count);
+                                }
                             }
                         }
                         if (task != null) {
@@ -416,6 +435,8 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
             }
 
             // Conditional requirements
+            // This block is maintained for backwards compatibility but datapacks
+            // should prefer expressing these as dedicated tasks instead.
             List<ResearchCondition> conditions = new ArrayList<>();
             if (json.has("conditional_requirements") && json.get("conditional_requirements").isJsonObject()) {
                 JsonObject cond = json.getAsJsonObject("conditional_requirements");
@@ -450,7 +471,7 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
             }
 
             ResearchEntry entry = new ResearchEntry(entryId, title, description, chapter, icon,
-                                                    prerequisites, unlocks, x, y, type, additional, tasks);
+                                                    prerequisites, unlocks, x, y, type, additional, tasks, conditions);
 
             LOADED_RESEARCH_ENTRIES.put(entryId, entry);
             RESEARCH_EXTENSIONS.computeIfAbsent(chapter, k -> new ArrayList<>()).add(entry);

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/ResearchEntry.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/ResearchEntry.java
@@ -33,6 +33,7 @@ public class ResearchEntry {
     private final ResearchType type;
     private final JsonObject additionalData;
     private final java.util.Map<Integer, java.util.List<ResearchTask>> tasks;
+    private final List<ResearchCondition> conditions;
 
     public enum ResearchType {
         BASIC("basic"),
@@ -56,7 +57,8 @@ public class ResearchEntry {
                         ResourceLocation chapter, ItemStack icon, List<ResourceLocation> prerequisites,
                         List<ResourceLocation> unlocks, int x, int y, ResearchType type,
                         JsonObject additionalData,
-                        java.util.Map<Integer, java.util.List<ResearchTask>> tasks) {
+                        java.util.Map<Integer, java.util.List<ResearchTask>> tasks,
+                        List<ResearchCondition> conditions) {
         this.id = id;
         this.title = title;
         this.description = description;
@@ -69,7 +71,7 @@ public class ResearchEntry {
         this.type = type;
         this.additionalData = additionalData != null ? additionalData : new JsonObject();
         this.tasks = tasks != null ? tasks : new java.util.HashMap<>();
-
+        this.conditions = conditions != null ? conditions : new ArrayList<>();
     }
 
     // Getters
@@ -85,6 +87,7 @@ public class ResearchEntry {
     public ResearchType getType() { return type; }
     public JsonObject getAdditionalData() { return additionalData; }
     public java.util.Map<Integer, java.util.List<ResearchTask>> getTasks() { return tasks; }
+    public List<ResearchCondition> getConditions() { return conditions; }
 
     /**
      * Converts this research entry to a JSON format for datapack generation
@@ -184,6 +187,24 @@ public class ResearchEntry {
                             tObj.addProperty("item", t.getItem().toString());
                             tObj.addProperty("count", t.getCount());
                         }
+                        case ENTER_DIMENSION -> {
+                            var t = (com.bluelotuscoding.eidolonunchained.research.tasks.EnterDimensionTask) task;
+                            tObj.addProperty("dimension", t.getDimension().toString());
+                        }
+                        case TIME_WINDOW -> {
+                            var t = (com.bluelotuscoding.eidolonunchained.research.tasks.TimeWindowTask) task;
+                            tObj.addProperty("min", t.getMin());
+                            tObj.addProperty("max", t.getMax());
+                        }
+                        case WEATHER -> {
+                            var t = (com.bluelotuscoding.eidolonunchained.research.tasks.WeatherTask) task;
+                            tObj.addProperty("weather", t.getWeather().name().toLowerCase());
+                        }
+                        case INVENTORY -> {
+                            var t = (com.bluelotuscoding.eidolonunchained.research.tasks.InventoryTask) task;
+                            tObj.addProperty("item", t.getItem().toString());
+                            tObj.addProperty("count", t.getCount());
+                        }
                     }
                     array.add(tObj);
                 }
@@ -211,6 +232,7 @@ public class ResearchEntry {
         private ResearchType type = ResearchType.BASIC;
         private JsonObject additionalData = new JsonObject();
         private java.util.Map<Integer, java.util.List<ResearchTask>> tasks = new java.util.HashMap<>();
+        private List<ResearchCondition> conditions = new ArrayList<>();
 
         public Builder(ResourceLocation id) {
             this.id = id;
@@ -268,9 +290,14 @@ public class ResearchEntry {
             return this;
         }
 
+        public Builder condition(ResearchCondition condition) {
+            this.conditions.add(condition);
+            return this;
+        }
+
         public ResearchEntry build() {
             return new ResearchEntry(id, title, description, chapter, icon,
-                                   prerequisites, unlocks, x, y, type, additionalData, tasks);
+                                   prerequisites, unlocks, x, y, type, additionalData, tasks, conditions);
 
         }
     }

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/EnterDimensionTask.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/EnterDimensionTask.java
@@ -1,0 +1,30 @@
+package com.bluelotuscoding.eidolonunchained.research.tasks;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Task requiring the player to be present in a specific dimension.
+ * <p>This mirrors {@link com.bluelotuscoding.eidolonunchained.research.conditions.DimensionCondition}
+ * but is expressed as a task so that it can participate in the normal research
+ * objective system.</p>
+ */
+public class EnterDimensionTask extends ResearchTask {
+    private final ResourceLocation dimension;
+
+    public EnterDimensionTask(ResourceLocation dimension) {
+        super(TaskType.ENTER_DIMENSION);
+        this.dimension = dimension;
+    }
+
+    public ResourceLocation getDimension() {
+        return dimension;
+    }
+
+    @Override
+    public boolean isComplete(Player player) {
+        if (player == null) return false;
+        return player.level().dimension().location().equals(dimension);
+    }
+}
+

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/InventoryTask.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/InventoryTask.java
@@ -1,0 +1,45 @@
+package com.bluelotuscoding.eidolonunchained.research.tasks;
+
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/**
+ * Task requiring the player to possess a specified number of an item.
+ */
+public class InventoryTask extends ResearchTask {
+    private final ResourceLocation item;
+    private final int count;
+
+    public InventoryTask(ResourceLocation item, int count) {
+        super(TaskType.INVENTORY);
+        this.item = item;
+        this.count = count;
+    }
+
+    public ResourceLocation getItem() {
+        return item;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean isComplete(Player player) {
+        if (player == null) return false;
+        Item mcItem = ForgeRegistries.ITEMS.getValue(item);
+        if (mcItem == null) return false;
+        int found = 0;
+        for (ItemStack stack : player.getInventory().items) {
+            if (stack.is(mcItem)) {
+                found += stack.getCount();
+                if (found >= count) return true;
+            }
+        }
+        return false;
+    }
+}
+

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTask.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTask.java
@@ -1,6 +1,7 @@
 package com.bluelotuscoding.eidolonunchained.research.tasks;
 
 import java.util.Locale;
+import net.minecraft.world.entity.player.Player;
 
 /**
  * Basic representation of a research task parsed from JSON.
@@ -18,13 +19,33 @@ public abstract class ResearchTask {
     }
 
     /**
+     * Checks whether this task is considered complete for the given player.
+     *
+     * <p>Most tasks track progress through the base Eidolon research system and
+     * thus always return {@code false} here.  Tasks that mirror
+     * {@link com.bluelotuscoding.eidolonunchained.research.conditions.ResearchCondition}
+     * implementations can override this to provide on‑the‑fly evaluation and
+     * automatically mark themselves complete.</p>
+     *
+     * @param player the player to test against
+     * @return {@code true} if the task has been satisfied
+     */
+    public boolean isComplete(Player player) {
+        return false;
+    }
+
+    /**
      * Supported task types.
      */
     public enum TaskType {
         KILL_ENTITIES("kill_entities"),
         CRAFT_ITEMS("craft_items"),
         USE_RITUAL("use_ritual"),
-        COLLECT_ITEMS("collect_items");
+        COLLECT_ITEMS("collect_items"),
+        ENTER_DIMENSION("enter_dimension"),
+        TIME_WINDOW("time_window"),
+        WEATHER("weather"),
+        INVENTORY("inventory");
 
         private final String id;
 

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/TimeWindowTask.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/TimeWindowTask.java
@@ -1,0 +1,38 @@
+package com.bluelotuscoding.eidolonunchained.research.tasks;
+
+import net.minecraft.world.entity.player.Player;
+
+/**
+ * Task requiring the world time to fall within a specific range.
+ */
+public class TimeWindowTask extends ResearchTask {
+    private final long min;
+    private final long max;
+
+    public TimeWindowTask(long min, long max) {
+        super(TaskType.TIME_WINDOW);
+        this.min = min;
+        this.max = max;
+    }
+
+    public long getMin() {
+        return min;
+    }
+
+    public long getMax() {
+        return max;
+    }
+
+    @Override
+    public boolean isComplete(Player player) {
+        if (player == null) return false;
+        long time = player.level().getDayTime() % 24000L;
+        if (min <= max) {
+            return time >= min && time <= max;
+        } else {
+            // wrap around midnight
+            return time >= min || time <= max;
+        }
+    }
+}
+

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/WeatherTask.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/WeatherTask.java
@@ -1,0 +1,40 @@
+package com.bluelotuscoding.eidolonunchained.research.tasks;
+
+import com.bluelotuscoding.eidolonunchained.research.conditions.WeatherCondition;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.Level;
+
+/**
+ * Task requiring a particular weather state.
+ */
+public class WeatherTask extends ResearchTask {
+    private final WeatherCondition.WeatherType weather;
+
+    public WeatherTask(String weather) {
+        super(TaskType.WEATHER);
+        String w = weather.toLowerCase();
+        if (w.equals("rain") || w.equals("raining")) {
+            this.weather = WeatherCondition.WeatherType.RAIN;
+        } else if (w.equals("thunder") || w.equals("thunderstorm")) {
+            this.weather = WeatherCondition.WeatherType.THUNDER;
+        } else {
+            this.weather = WeatherCondition.WeatherType.CLEAR;
+        }
+    }
+
+    public WeatherCondition.WeatherType getWeather() {
+        return weather;
+    }
+
+    @Override
+    public boolean isComplete(Player player) {
+        if (player == null) return false;
+        Level level = player.level();
+        return switch (weather) {
+            case CLEAR -> !level.isRaining();
+            case RAIN -> level.isRaining() && !level.isThundering();
+            case THUNDER -> level.isThundering();
+        };
+    }
+}
+


### PR DESCRIPTION
## Summary
- add task variants for dimension, time, weather and inventory requirements
- parse and register new task ids in `ResearchDataManager`
- expose research conditions for serialization and builder use
- document shift from conditional requirements to task-based equivalents

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a5f2e08f9883278f185e86213d75e9