### PR TITLE
docs: clarify conditions vs tasks

### DIFF
--- a/docs/DATAPACK_STRUCTURE.md
+++ b/docs/DATAPACK_STRUCTURE.md
@@ -81,6 +81,9 @@ See [Codex Tutorial](codex_tutorial.md) for a guided walkthrough and [Codex Refe
   "title": "Research Title",
   "description": "Research description",
   "required_stars": 3,                               // ← Stars needed to unlock
+  "conditions": {                                    // ← Optional gating
+    "dimension": "minecraft:the_nether"
+  },
   "special_tasks": [                                 // ← Special requirements
     "Kill 100 zombies with void magic"
   ],
@@ -102,6 +105,8 @@ See [Codex Tutorial](codex_tutorial.md) for a guided walkthrough and [Codex Refe
   }
 }
 ```
+
+Conditions act as prerequisites for the entry; tasks only begin tracking once all conditions are satisfied.
 
 ## 🎯 **Available Eidolon Chapters**
 *(Use these exact names for built-in chapters or a namespaced ID for custom ones)*

--- a/docs/RESEARCH_CONDITIONS.md
+++ b/docs/RESEARCH_CONDITIONS.md
@@ -1,39 +1,41 @@
 # Research Condition Types
 
-Eidolon Unchained research entries can specify **conditional_requirements** to gate
+Eidolon Unchained research entries can specify **conditions** to gate
 a research until certain world or player states are met. The following condition
 types are supported:
 
+Each condition mirrors a task-based equivalent, allowing you to gate an entry globally or require the same context as part of its tasks.
+
 ## Dimension
 ```json
-"conditional_requirements": {
+"conditions": {
   "dimension": "minecraft:the_nether"
 }
 ```
-*The player must be in the specified dimension.*
+*The player must be in the specified dimension.* Task-based equivalent: `EnterDimensionTask`.
 
 ## Time Range
 ```json
-"conditional_requirements": {
+"conditions": {
   "time_range": { "min": 13000, "max": 23000 }
 }
 ```
-*Only valid when the world time (0-24000) is within the range. Wraps around midnight when `min` is greater than `max`.*
+*Only valid when the world time (0-24000) is within the range. Wraps around midnight when `min` is greater than `max`.* Task-based equivalent: `TimeWindowTask`.
 
 ## Weather
 ```json
-"conditional_requirements": {
+"conditions": {
   "weather": "thunder"
 }
 ```
-*Valid weather values: `clear`, `rain`, `thunder`. The condition passes when the world's weather matches.*
+*Valid weather values: `clear`, `rain`, `thunder`. The condition passes when the world's weather matches.* Task-based equivalent: `WeatherTask`.
 
 ## Inventory Items
 ```json
-"conditional_requirements": {
+"conditions": {
   "inventory": [
     { "item": "eidolon:athame", "count": 1 }
   ]
 }
 ```
-*All listed items must be present in the player's inventory in at least the specified quantity.*
+*All listed items must be present in the player's inventory in at least the specified quantity.* Task-based equivalent: `InventoryTask`.

--- a/docs/datapack_overview.md
+++ b/docs/datapack_overview.md
@@ -26,6 +26,7 @@ data/
 4. **Research**
    - `research_chapters/` organize research topics and can reference a category ID.
    - `research_entries/` link to a research chapter and may unlock codex entries.
+   - Entries may specify `conditions` that must be met before their `tasks` can progress.
 
 ## Required and Optional Fields
 
@@ -35,7 +36,7 @@ data/
 | **Codex Chapter** | `title` | `icon` |
 | **Codex Entry** | `target_chapter`, `pages` | `title`, `description`, `icon`, `prerequisites`, `type` |
 | **Research Chapter** | `id`, `title`, `description`, `category`, `icon` | `background`, `position` |
-| **Research Entry** | `id`, `title`, `description`, `chapter` | `icon`, `prerequisites`, `unlocks`, `star_requirement`, `tasks`, `rewards` |
+| **Research Entry** | `id`, `title`, `description`, `chapter` | `icon`, `prerequisites`, `unlocks`, `star_requirement`, `conditions`, `tasks`, `rewards` |
 
 ### Cross References
 
@@ -106,6 +107,7 @@ data/
   "description": "yourmod.research.void_step.desc",
   "chapter": "yourmod:void_mastery",
   "star_requirement": 2,
+  "conditions": { "dimension": "minecraft:the_nether" },
   "tasks": {
     "tier_1": [
       { "type": "use_ritual", "ritual": "yourmod:void_portal", "count": 1 }
@@ -116,3 +118,5 @@ data/
   }
 }
 ```
+
+In this example, tasks only track progress while the player is in the Nether because of the `dimension` condition.

--- a/docs/research_entries.md
+++ b/docs/research_entries.md
@@ -13,9 +13,13 @@ This guide explains how to define research entries for Eidolon Unchained. Each e
 | `unlocks` | Research IDs made available after completion. |
 | `type` | Entry category: `basic`, `advanced`, `forbidden`, `ritual`, or `crafting`. |
 | `x`, `y` | Coordinates on the research screen grid. |
-| `conditions` | Deprecated in favour of task‑based equivalents. Older datapacks may still use this section to gate entries by dimension, time or inventory. |
+| `conditions` | Environmental or player state requirements that must be met before progress begins. Conditions gate when tasks are eligible to run, letting you restrict entries by dimension, time, weather, or inventory. |
 | `tasks` | Objectives the player must complete. Each task uses a specific task class such as `KillEntitiesTask`, `CollectItemsTask`, `UseRitualTask`, `EnterDimensionTask`, `TimeWindowTask`, `WeatherTask`, or `InventoryTask`. |
 | `rewards` | Extra benefits granted on completion (items, advancements, unlocks). |
+
+> **Note:** The JSON key for conditions is `"conditions"`. Earlier drafts of the documentation used `"conditional_requirements"`, but that name has been retired.
+
+Conditions and tasks complement each other—conditions set the scene, limiting when a research entry is active, while tasks define the actions the player must perform once those conditions are met.
 
 ## ⭐ Star Requirements
 


### PR DESCRIPTION
## Summary
- Clarify that research entries use a `conditions` field and explain its relationship with `tasks`
- Align RESEARCH_CONDITIONS guide with new terminology and reference task equivalents
- Update datapack structure and overview examples to include `conditions`

## Testing
- `./gradlew test` *(fails: variable conditions is already defined in class ResearchEntry)*

------
https://chatgpt.com/codex/tasks/task_e_68a6078e39748327be725349ad1efada