### PR TITLE
Remove unused special_tasks field

### DIFF
--- a/docs/DATAPACK_STRUCTURE.md
+++ b/docs/DATAPACK_STRUCTURE.md
@@ -84,14 +84,11 @@ See [Codex Tutorial](codex_tutorial.md) for a guided walkthrough and [Codex Refe
   "conditions": {                                    // ← Optional gating
     "dimension": "minecraft:the_nether"
   },
-  "special_tasks": [                                 // ← Special requirements
-    "Kill 100 zombies with void magic"
-  ],
   "tasks": {                                         // ← Progression tasks
     "tier_1": [
       {
         "type": "kill_entities",
-        "entity": "minecraft:zombie", 
+        "entity": "minecraft:zombie",
         "count": 50
       }
     ],

--- a/src/main/resources/data/eidolonunchained/research_entries/advanced_soul_manipulation.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/advanced_soul_manipulation.json
@@ -11,9 +11,6 @@
   "type": "advanced",
   "additional": {
     "required_stars": 5,
-    "special_tasks": [
-      "Perform 50 soul enchantments"
-    ],
     "tasks": {
       "tier_1": [
         {"type": "kill_entities", "entity": "minecraft:zombie", "count": 100}

--- a/src/main/resources/data/eidolonunchained/research_entries/master_necromancer.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/master_necromancer.json
@@ -11,10 +11,6 @@
   "type": "advanced",
   "additional": {
     "required_stars": 4,
-    "special_tasks": [
-      "Successfully perform 50 necromantic rituals",
-      "Command 10 different types of undead creatures"
-    ],
     "tasks": {
       "tier_1": [
         {"type": "kill_entities", "entity": "minecraft:zombie", "count": 150},

--- a/src/main/resources/data/eidolonunchained/research_entries/ritual_master.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/ritual_master.json
@@ -11,10 +11,6 @@
   "type": "ritual",
   "additional": {
     "required_stars": 4,
-    "special_tasks": [
-      "Perform 25 different types of rituals",
-      "Successfully combine two rituals in sequence"
-    ],
     "tasks": {
       "tier_1": [
         {"type": "use_ritual", "ritual": "eidolon:crystal_ritual", "count": 10},

--- a/src/main/resources/data/eidolonunchained/research_entries/soul_binding_mastery.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/soul_binding_mastery.json
@@ -11,10 +11,6 @@
   "type": "advanced",
   "additional": {
     "required_stars": 3,
-    "special_tasks": [
-      "Successfully bind 25 souls to gems",
-      "Create soul-enhanced equipment"
-    ],
     "tasks": {
       "tier_1": [
         {"type": "collect_items", "item": "eidolon:soul_shard", "count": 50},

--- a/src/main/resources/data/eidolonunchained/research_entries/void_walker.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/void_walker.json
@@ -11,10 +11,6 @@
   "type": "advanced",
   "additional": {
     "required_stars": 3,
-    "special_tasks": [
-      "Successfully craft 10 void-enhanced items",
-      "Travel through the End dimension for 2 hours"
-    ],
     "tasks": {
       "tier_1": [
         {"type": "collect_items", "item": "minecraft:ender_pearl", "count": 64},


### PR DESCRIPTION
## Summary
- Drop unimplemented `special_tasks` section from datapack structure docs
- Remove `special_tasks` field from all sample research entry JSON files

## Testing
- `./gradlew test` *(fails: variable `conditions` already defined in `ResearchEntry`, patterns in switch statements disabled, and unresolved symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68a60feb1ad88327985c176288c3a1a2