### PR TITLE
docs: rename conditional_requirements to conditions

### DIFF
--- a/docs/RESEARCH_CONDITIONS.md
+++ b/docs/RESEARCH_CONDITIONS.md
@@ -1,8 +1,8 @@
 # Research Condition Types
 
-Eidolon Unchained research entries can specify **conditions** to gate
-a research until certain world or player states are met. The following condition
-types are supported:
+Eidolon Unchained research entries can specify **conditions** to gate a research until certain world or player states are met. The following condition types are supported.
+
+> **Backward Compatibility:** Earlier documentation referred to this key as `conditional_requirements`. The old name is still accepted but will be removed in a future release.
 
 Each condition mirrors a task-based equivalent, allowing you to gate an entry globally or require the same context as part of its tasks.
 


### PR DESCRIPTION
## Summary
- rename conditional_requirements to conditions in research condition docs
- note deprecated key for backward compatibility

## Testing
- `./gradlew test` *(fails: variable definitions conflict and compilation errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a60ffa46a88327935fc0117b5dcda7