### PR TITLE
Add support for required stars in research entries

### DIFF
--- a/docs/DATAPACK_STRUCTURE.md
+++ b/docs/DATAPACK_STRUCTURE.md
@@ -80,7 +80,7 @@ See [Codex Tutorial](codex_tutorial.md) for a guided walkthrough and [Codex Refe
   "research_id": "yourmod:new_research_id",           // ← Your research ID
   "title": "Research Title",
   "description": "Research description",
-  "required_stars": 3,                               // ← Stars needed to unlock
+  "required_stars": 3,                               // ← Stars needed to unlock; defaults by type if omitted
   "conditions": {                                    // ← Optional gating
     "dimension": "minecraft:the_nether"
   },

--- a/docs/datapack_overview.md
+++ b/docs/datapack_overview.md
@@ -36,7 +36,9 @@ data/
 | **Codex Chapter** | `title` | `icon` |
 | **Codex Entry** | `target_chapter`, `pages` | `title`, `description`, `icon`, `prerequisites`, `type` |
 | **Research Chapter** | `id`, `title`, `description`, `category`, `icon` | `background`, `position` |
-| **Research Entry** | `id`, `title`, `description`, `chapter` | `icon`, `prerequisites`, `unlocks`, `star_requirement`, `conditions`, `tasks`, `rewards` |
+| **Research Entry** | `id`, `title`, `description`, `chapter` | `icon`, `prerequisites`, `unlocks`, `required_stars`, `conditions`, `tasks`, `rewards` |
+
+`required_stars` is optional; if omitted, the game assigns star costs based on the entry type (0 for basic/crafting, 1 for advanced/ritual, 2 for forbidden).
 
 ### Cross References
 
@@ -106,7 +108,7 @@ data/
   "title": "yourmod.research.void_step",
   "description": "yourmod.research.void_step.desc",
   "chapter": "yourmod:void_mastery",
-  "star_requirement": 2,
+  "required_stars": 2,
   "conditions": { "dimension": "minecraft:the_nether" },
   "tasks": {
     "tier_1": [

--- a/docs/research_entries.md
+++ b/docs/research_entries.md
@@ -23,7 +23,7 @@ Conditions and tasks complement each other—conditions set the scene, limiting 
 
 ## ⭐ Star Requirements
 
-The `required_stars` value gates access to higher‑tier research. Star costs should scale with entry complexity and reward.
+The `required_stars` value gates access to higher‑tier research. Star costs should scale with entry complexity and reward. If omitted, star costs fall back to the entry type: 0 for `basic` or `crafting`, 1 for `advanced` or `ritual`, and 2 for `forbidden` entries.
 
 ## 📊 Task Tiers
 

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
@@ -338,6 +338,17 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
                 }
             }
 
+            int requiredStars = -1;
+            if (json.has("required_stars")) {
+                requiredStars = json.get("required_stars").getAsInt();
+            } else if (json.has("additional") && json.get("additional").isJsonObject()) {
+                JsonObject addObj = json.getAsJsonObject("additional");
+                if (addObj.has("required_stars")) {
+                    requiredStars = addObj.get("required_stars").getAsInt();
+                    addObj.remove("required_stars");
+                }
+            }
+
             // Tasks parsing
             Map<Integer, List<com.bluelotuscoding.eidolonunchained.research.tasks.ResearchTask>> tasks = new HashMap<>();
             JsonObject tasksContainer = null;
@@ -438,7 +449,7 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
             // Additional custom fields
             JsonObject additional = new JsonObject();
             Set<String> known = Set.of("id", "title", "description", "chapter", "icon",
-                                       "prerequisites", "unlocks", "x", "y", "type", "tasks", "additional");
+                                       "prerequisites", "unlocks", "x", "y", "type", "required_stars", "tasks", "additional");
             for (Map.Entry<String, JsonElement> e : json.entrySet()) {
                 if (!known.contains(e.getKey())) {
                     additional.add(e.getKey(), e.getValue());
@@ -488,7 +499,7 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
             }
 
             ResearchEntry entry = new ResearchEntry(entryId, title, description, chapter, icon,
-                                                    prerequisites, unlocks, x, y, type, additional, tasks, conditions);
+                                                    prerequisites, unlocks, x, y, type, requiredStars, additional, tasks, conditions);
 
             LOADED_RESEARCH_ENTRIES.put(entryId, entry);
             RESEARCH_EXTENSIONS.computeIfAbsent(chapter, k -> new ArrayList<>()).add(entry);

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonResearchIntegration.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonResearchIntegration.java
@@ -96,13 +96,15 @@ public class EidolonResearchIntegration {
      * Creates a Research object from our ResearchEntry data.
      */
     private static Research createResearchFromEntry(ResearchEntry entry) {
-        int stars;
-        switch (entry.getType()) {
-            case ADVANCED -> stars = 1;
-            case FORBIDDEN -> stars = 2;
-            case RITUAL -> stars = 1;
-            case CRAFTING, BASIC -> stars = 0;
-            default -> stars = 0;
+        int stars = entry.getRequiredStars();
+        if (stars < 0) {
+            switch (entry.getType()) {
+                case ADVANCED -> stars = 1;
+                case FORBIDDEN -> stars = 2;
+                case RITUAL -> stars = 1;
+                case CRAFTING, BASIC -> stars = 0;
+                default -> stars = 0;
+            }
         }
         return new CustomResearch(entry, stars);
     }

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/ResearchEntry.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/ResearchEntry.java
@@ -34,6 +34,7 @@ public class ResearchEntry {
     private final int x;
     private final int y;
     private final ResearchType type;
+    private final int requiredStars;
     private final JsonObject additionalData;
     private final java.util.Map<Integer, java.util.List<ResearchTask>> tasks;
     private final List<ResearchCondition> conditions;
@@ -59,7 +60,7 @@ public class ResearchEntry {
     public ResearchEntry(ResourceLocation id, Component title, Component description,
                         ResourceLocation chapter, ItemStack icon, List<ResourceLocation> prerequisites,
                         List<ResourceLocation> unlocks, int x, int y, ResearchType type,
-                        JsonObject additionalData,
+                        int requiredStars, JsonObject additionalData,
                         java.util.Map<Integer, java.util.List<ResearchTask>> tasks,
                         List<ResearchCondition> conditions) {
         this.id = id;
@@ -73,6 +74,7 @@ public class ResearchEntry {
         this.x = x;
         this.y = y;
         this.type = type;
+        this.requiredStars = requiredStars;
         this.additionalData = additionalData != null ? additionalData : new JsonObject();
         this.tasks = tasks != null ? tasks : new java.util.HashMap<>();
         this.conditions = conditions != null ? conditions : new ArrayList<>();
@@ -89,6 +91,7 @@ public class ResearchEntry {
     public int getX() { return x; }
     public int getY() { return y; }
     public ResearchType getType() { return type; }
+    public int getRequiredStars() { return requiredStars; }
     public JsonObject getAdditionalData() { return additionalData; }
     public List<ResearchCondition> getConditions() {
         return Collections.unmodifiableList(new ArrayList<>(conditions));
@@ -107,6 +110,9 @@ public class ResearchEntry {
         json.addProperty("description", description.getString());
         json.addProperty("chapter", chapter.toString());
         json.addProperty("type", type.getName());
+        if (requiredStars >= 0) {
+            json.addProperty("required_stars", requiredStars);
+        }
         json.addProperty("x", x);
         json.addProperty("y", y);
 
@@ -238,6 +244,7 @@ public class ResearchEntry {
         private int x = 0;
         private int y = 0;
         private ResearchType type = ResearchType.BASIC;
+        private int requiredStars = -1;
         private JsonObject additionalData = new JsonObject();
         private java.util.Map<Integer, java.util.List<ResearchTask>> tasks = new java.util.HashMap<>();
         private List<ResearchCondition> conditions = new ArrayList<>();
@@ -292,6 +299,11 @@ public class ResearchEntry {
             return this;
         }
 
+        public Builder requiredStars(int stars) {
+            this.requiredStars = stars;
+            return this;
+        }
+
         public Builder additionalData(String key, String value) {
             this.additionalData.addProperty(key, value);
             return this;
@@ -319,7 +331,7 @@ public class ResearchEntry {
 
         public ResearchEntry build() {
             return new ResearchEntry(id, title, description, chapter, icon,
-                                   prerequisites, unlocks, x, y, type, additionalData, tasks, conditions);
+                                   prerequisites, unlocks, x, y, type, requiredStars, additionalData, tasks, conditions);
 
         }
     }

--- a/src/main/resources/data/eidolonunchained/research_entries/advanced_soul_manipulation.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/advanced_soul_manipulation.json
@@ -9,8 +9,8 @@
   "x": 0,
   "y": 0,
   "type": "advanced",
+  "required_stars": 5,
   "additional": {
-    "required_stars": 5,
     "special_tasks": [
       "Perform 50 soul enchantments"
     ],

--- a/src/main/resources/data/eidolonunchained/research_entries/master_necromancer.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/master_necromancer.json
@@ -9,8 +9,8 @@
   "x": 0,
   "y": 0,
   "type": "advanced",
+  "required_stars": 4,
   "additional": {
-    "required_stars": 4,
     "special_tasks": [
       "Successfully perform 50 necromantic rituals",
       "Command 10 different types of undead creatures"

--- a/src/main/resources/data/eidolonunchained/research_entries/ritual_master.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/ritual_master.json
@@ -9,8 +9,8 @@
   "x": 0,
   "y": 0,
   "type": "ritual",
+  "required_stars": 4,
   "additional": {
-    "required_stars": 4,
     "special_tasks": [
       "Perform 25 different types of rituals",
       "Successfully combine two rituals in sequence"

--- a/src/main/resources/data/eidolonunchained/research_entries/soul_binding_mastery.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/soul_binding_mastery.json
@@ -9,8 +9,8 @@
   "x": 0,
   "y": 0,
   "type": "advanced",
+  "required_stars": 3,
   "additional": {
-    "required_stars": 3,
     "special_tasks": [
       "Successfully bind 25 souls to gems",
       "Create soul-enhanced equipment"

--- a/src/main/resources/data/eidolonunchained/research_entries/void_walker.json
+++ b/src/main/resources/data/eidolonunchained/research_entries/void_walker.json
@@ -9,8 +9,8 @@
   "x": 0,
   "y": 0,
   "type": "advanced",
+  "required_stars": 3,
   "additional": {
-    "required_stars": 3,
     "special_tasks": [
       "Successfully craft 10 void-enhanced items",
       "Travel through the End dimension for 2 hours"


### PR DESCRIPTION
## Summary
- Parse top-level `required_stars` when loading research entries and propagate to `ResearchEntry`
- Use `required_stars` in research integration with type-based fallback
- Move `required_stars` to the root of example research entry JSON files and document the behavior

## Testing
- `./gradlew -q compileJava` *(fails: variable/method duplicates and missing symbols)*

------
https://chatgpt.com/codex/tasks/task_e_68a618daa4e88327b62245ef13921559