### PR TITLE
Add HasNbt research task type

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
@@ -435,6 +435,14 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
                                     int count = tobj.has("count") ? tobj.get("count").getAsInt() : 1;
                                     task = new InventoryTask(item, count);
                                 }
+                                case HAS_NBT -> {
+                                    try {
+                                        CompoundTag tag = TagParser.parseTag(tobj.get("nbt").getAsString());
+                                        task = new HasNbtTask(tag);
+                                    } catch (Exception e) {
+                                        LOGGER.warn("Failed to parse NBT for task in research {}", entryId, e);
+                                    }
+                                }
                             }
                         }
                         try {

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/HasNbtTask.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/HasNbtTask.java
@@ -1,0 +1,39 @@
+package com.bluelotuscoding.eidolonunchained.research.tasks;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.server.level.ServerPlayer;
+
+/**
+ * Task requiring the player's persistent NBT data to contain a specific tag.
+ */
+public class HasNbtTask extends ResearchTask {
+    private final CompoundTag required;
+
+    public HasNbtTask(CompoundTag required) {
+        super(ResearchTaskTypes.HAS_NBT);
+        this.required = required;
+    }
+
+    /**
+     * @return the NBT tag that must be present on the player
+     */
+    public CompoundTag getRequired() {
+        return required;
+    }
+
+    /**
+     * Checks completion against a server player by comparing their persistent
+     * data to the required tag.
+     */
+    public boolean isComplete(ServerPlayer player) {
+        return player != null && NbtUtils.compareNbt(required, player.getPersistentData(), true);
+    }
+
+    @Override
+    public boolean isComplete(Player player) {
+        return player instanceof ServerPlayer sp && isComplete(sp);
+    }
+}
+

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTask.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTask.java
@@ -46,7 +46,8 @@ public abstract class ResearchTask {
         TIME_WINDOW("time_window"),
         WEATHER("weather"),
         INVENTORY("inventory"),
-        EXPLORE_BIOMES("explore_biomes");
+        EXPLORE_BIOMES("explore_biomes"),
+        HAS_NBT("has_nbt");
 
         private final String id;
 

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTaskTypes.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTaskTypes.java
@@ -2,6 +2,8 @@ package com.bluelotuscoding.eidolonunchained.research.tasks;
 
 import com.bluelotuscoding.eidolonunchained.EidolonUnchained;
 import com.google.gson.JsonObject;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.TagParser;
 import net.minecraft.resources.ResourceLocation;
 
 import java.util.HashMap;
@@ -30,6 +32,7 @@ public class ResearchTaskTypes {
     public static ResearchTaskType USE_RITUAL;
     public static ResearchTaskType COLLECT_ITEMS;
     public static ResearchTaskType EXPLORE_BIOMES;
+    public static ResearchTaskType HAS_NBT;
 
     /**
      * Registers the built-in task types. Should be called during mod
@@ -60,6 +63,15 @@ public class ResearchTaskTypes {
             ResourceLocation biome = ResourceLocation.tryParse(json.get("biome").getAsString());
             int count = json.has("count") ? json.get("count").getAsInt() : 1;
             return new ExploreBiomesTask(biome, count);
+        });
+        HAS_NBT = register(new ResourceLocation(EidolonUnchained.MODID, "has_nbt"), json -> {
+            if (!json.has("nbt")) return null;
+            try {
+                CompoundTag tag = TagParser.parseTag(json.get("nbt").getAsString());
+                return new HasNbtTask(tag);
+            } catch (Exception e) {
+                return null;
+            }
         });
     }
 }


### PR DESCRIPTION
## Summary
- add HasNbtTask to compare player persistent data against required NBT
- register HAS_NBT research task type and enum entry
- parse `has_nbt` task definitions in ResearchDataManager

## Testing
- `./gradlew test` *(fails: variable conditions defined twice; preview switch patterns disabled)*

------
https://chatgpt.com/codex/tasks/task_e_68a629d2b0f0832781a94e62edc5c282