### PR TITLE
Use task type decoders and add HAS_ITEM_NBT

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
@@ -394,19 +394,7 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
                         }
                         com.bluelotuscoding.eidolonunchained.research.tasks.ResearchTask task;
                         try {
-                            if (taskType == ResearchTaskTypes.KILL_ENTITY_NBT) {
-                                ResourceLocation entity = ResourceLocation.tryParse(tobj.get("entity").getAsString());
-                                CompoundTag filter = null;
-                                if (tobj.has("filter")) {
-                                    try {
-                                        filter = TagParser.parseTag(tobj.get("filter").getAsString());
-                                    } catch (Exception ignored) {}
-                                }
-                                int count = tobj.has("count") ? tobj.get("count").getAsInt() : 1;
-                                task = new KillEntityWithNbtTask(entity, filter, count);
-                            } else {
-                                task = taskType.decoder().apply(tobj);
-                            }
+                            task = taskType.decoder().apply(tobj);
                         } catch (Exception e) {
                             LOGGER.warn("Failed to parse task of type '{}' in research {}", typeStr, entryId, e);
                             continue;

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/ResearchEntry.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/ResearchEntry.java
@@ -201,6 +201,13 @@ public class ResearchEntry {
                         var t = (com.bluelotuscoding.eidolonunchained.research.tasks.CollectItemsTask) task;
                         tObj.addProperty("item", t.getItem().toString());
                         tObj.addProperty("count", t.getCount());
+                    } else if (type == ResearchTaskTypes.HAS_ITEM_NBT) {
+                        var t = (com.bluelotuscoding.eidolonunchained.research.tasks.HasItemWithNbtTask) task;
+                        tObj.addProperty("item", t.getItem().toString());
+                        if (t.getFilter() != null) {
+                            tObj.addProperty("nbt", t.getFilter().toString());
+                        }
+                        tObj.addProperty("count", t.getCount());
                     } else if (type == ResearchTaskTypes.EXPLORE_BIOMES) {
                         var t = (com.bluelotuscoding.eidolonunchained.research.tasks.ExploreBiomesTask) task;
                         tObj.addProperty("biome", t.getBiome().toString());

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/HasItemWithNbtTask.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/HasItemWithNbtTask.java
@@ -1,0 +1,57 @@
+package com.bluelotuscoding.eidolonunchained.research.tasks;
+
+import javax.annotation.Nullable;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+
+/**
+ * Task requiring the player to possess a specific item with optional NBT data.
+ */
+public class HasItemWithNbtTask extends ResearchTask {
+    private final ResourceLocation item;
+    @Nullable
+    private final CompoundTag filter;
+    private final int count;
+
+    public HasItemWithNbtTask(ResourceLocation item, @Nullable CompoundTag filter, int count) {
+        super(ResearchTaskTypes.HAS_ITEM_NBT);
+        this.item = item;
+        this.filter = filter;
+        this.count = count;
+    }
+
+    public ResourceLocation getItem() {
+        return item;
+    }
+
+    @Nullable
+    public CompoundTag getFilter() {
+        return filter;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean isComplete(Player player) {
+        if (player == null) return false;
+        Item target = ForgeRegistries.ITEMS.getValue(item);
+        if (target == null) return false;
+        int found = 0;
+        for (ItemStack stack : player.getInventory().items) {
+            if (!stack.is(target)) continue;
+            if (filter != null && !NbtUtils.compareNbt(filter, stack.getTag(), true)) continue;
+            found += stack.getCount();
+            if (found >= count) return true;
+        }
+        return false;
+    }
+}
+

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTaskTypes.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTaskTypes.java
@@ -33,6 +33,7 @@ public class ResearchTaskTypes {
     public static ResearchTaskType USE_RITUAL;
     public static ResearchTaskType COLLECT_ITEMS;
     public static ResearchTaskType EXPLORE_BIOMES;
+    public static ResearchTaskType HAS_ITEM_NBT;
 
     /**
      * Registers the built-in task types. Should be called during mod
@@ -69,6 +70,21 @@ public class ResearchTaskTypes {
             ResourceLocation item = ResourceLocation.tryParse(json.get("item").getAsString());
             int count = json.has("count") ? json.get("count").getAsInt() : 1;
             return new CollectItemsTask(item, count);
+        });
+        HAS_ITEM_NBT = register(new ResourceLocation(EidolonUnchained.MODID, "has_item_nbt"), json -> {
+            ResourceLocation item = ResourceLocation.tryParse(json.get("item").getAsString());
+            CompoundTag filter = null;
+            if (json.has("nbt")) {
+                try {
+                    filter = TagParser.parseTag(json.get("nbt").getAsString());
+                } catch (Exception ignored) {}
+            } else if (json.has("filter")) {
+                try {
+                    filter = TagParser.parseTag(json.get("filter").getAsString());
+                } catch (Exception ignored) {}
+            }
+            int count = json.has("count") ? json.get("count").getAsInt() : 1;
+            return new HasItemWithNbtTask(item, filter, count);
         });
         EXPLORE_BIOMES = register(new ResourceLocation(EidolonUnchained.MODID, "explore_biomes"), json -> {
             ResourceLocation biome = ResourceLocation.tryParse(json.get("biome").getAsString());


### PR DESCRIPTION
## Summary
- Remove special-case task parsing and rely on `ResearchTaskType` decoders
- Add `HAS_ITEM_NBT` task type and decoder
- Serialize `HAS_ITEM_NBT` tasks in research entries

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a63186ee708327a9c22bf26a7a2220