### PR TITLE
feat: reintroduce task type registrations

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/HasItemWithNbtTask.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/HasItemWithNbtTask.java
@@ -1,0 +1,60 @@
+package com.bluelotuscoding.eidolonunchained.research.tasks;
+
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtUtils;
+import net.minecraft.resources.ResourceLocation;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.item.Item;
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.registries.ForgeRegistries;
+
+import javax.annotation.Nullable;
+
+/**
+ * Task requiring the player to possess an item that matches a given NBT filter.
+ */
+public class HasItemWithNbtTask extends ResearchTask {
+    private final ResourceLocation item;
+    @Nullable
+    private final CompoundTag filter;
+    private final int count;
+
+    public HasItemWithNbtTask(ResourceLocation item, @Nullable CompoundTag filter, int count) {
+        super(ResearchTaskTypes.HAS_ITEM_NBT);
+        this.item = item;
+        this.filter = filter;
+        this.count = count;
+    }
+
+    public ResourceLocation getItem() {
+        return item;
+    }
+
+    @Nullable
+    public CompoundTag getFilter() {
+        return filter;
+    }
+
+    public int getCount() {
+        return count;
+    }
+
+    @Override
+    public boolean isComplete(Player player) {
+        if (player == null) return false;
+        Item mcItem = ForgeRegistries.ITEMS.getValue(item);
+        if (mcItem == null) return false;
+        int found = 0;
+        for (ItemStack stack : player.getInventory().items) {
+            if (stack.is(mcItem)) {
+                if (filter != null) {
+                    CompoundTag tag = stack.getTag();
+                    if (tag == null || !NbtUtils.compareNbt(filter, tag, true)) continue;
+                }
+                found += stack.getCount();
+                if (found >= count) return true;
+            }
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTaskTypes.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/research/tasks/ResearchTaskTypes.java
@@ -32,6 +32,11 @@ public class ResearchTaskTypes {
     public static ResearchTaskType CRAFT_ITEMS;
     public static ResearchTaskType USE_RITUAL;
     public static ResearchTaskType COLLECT_ITEMS;
+    public static ResearchTaskType INVENTORY;
+    public static ResearchTaskType ENTER_DIMENSION;
+    public static ResearchTaskType TIME_WINDOW;
+    public static ResearchTaskType WEATHER;
+    public static ResearchTaskType HAS_ITEM_NBT;
     public static ResearchTaskType EXPLORE_BIOMES;
 
     /**
@@ -69,6 +74,35 @@ public class ResearchTaskTypes {
             ResourceLocation item = ResourceLocation.tryParse(json.get("item").getAsString());
             int count = json.has("count") ? json.get("count").getAsInt() : 1;
             return new CollectItemsTask(item, count);
+        });
+        INVENTORY = register(new ResourceLocation(EidolonUnchained.MODID, "inventory"), json -> {
+            ResourceLocation item = ResourceLocation.tryParse(json.get("item").getAsString());
+            int count = json.has("count") ? json.get("count").getAsInt() : 1;
+            return new InventoryTask(item, count);
+        });
+        ENTER_DIMENSION = register(new ResourceLocation(EidolonUnchained.MODID, "enter_dimension"), json -> {
+            ResourceLocation dimension = ResourceLocation.tryParse(json.get("dimension").getAsString());
+            return new EnterDimensionTask(dimension);
+        });
+        TIME_WINDOW = register(new ResourceLocation(EidolonUnchained.MODID, "time_window"), json -> {
+            long min = json.has("min") ? json.get("min").getAsLong() : 0L;
+            long max = json.has("max") ? json.get("max").getAsLong() : 0L;
+            return new TimeWindowTask(min, max);
+        });
+        WEATHER = register(new ResourceLocation(EidolonUnchained.MODID, "weather"), json -> {
+            String weather = json.get("weather").getAsString();
+            return new WeatherTask(weather);
+        });
+        HAS_ITEM_NBT = register(new ResourceLocation(EidolonUnchained.MODID, "has_item_nbt"), json -> {
+            ResourceLocation item = ResourceLocation.tryParse(json.get("item").getAsString());
+            CompoundTag filter = null;
+            if (json.has("filter")) {
+                try {
+                    filter = TagParser.parseTag(json.get("filter").getAsString());
+                } catch (Exception ignored) {}
+            }
+            int count = json.has("count") ? json.get("count").getAsInt() : 1;
+            return new HasItemWithNbtTask(item, filter, count);
         });
         EXPLORE_BIOMES = register(new ResourceLocation(EidolonUnchained.MODID, "explore_biomes"), json -> {
             ResourceLocation biome = ResourceLocation.tryParse(json.get("biome").getAsString());


### PR DESCRIPTION
## Summary
- register additional research task types like inventory, weather, time window and dimension
- add `HasItemWithNbtTask` and register new `has_item_nbt` task

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a63187fe9c83279817e8b568a498ba