### PR TITLE
feat: load datapack categories dynamically

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
@@ -11,6 +11,7 @@ import com.google.gson.JsonElement;
 import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraft.server.packs.resources.ResourceManager;
+import net.minecraft.server.packs.resources.Resource;
 import net.minecraft.server.packs.resources.SimpleJsonResourceReloadListener;
 import net.minecraft.util.profiling.ProfilerFiller;
 import net.minecraft.nbt.CompoundTag;
@@ -18,6 +19,7 @@ import net.minecraft.nbt.TagParser;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.Items;
 import net.minecraftforge.event.AddReloadListenerEvent;
 import net.minecraftforge.event.server.ServerStartedEvent;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
@@ -431,11 +433,11 @@ public class CodexDataManager extends SimpleJsonResourceReloadListener {
         public String title;
         public Item icon;
         public List<PageData> pages;
-        
+
         public DatapackEntry() {
             this.pages = new ArrayList<>();
         }
-        
+
         public DatapackEntry(String title_key, String title, Item icon) {
             this.title_key = title_key;
             this.title = title;
@@ -465,90 +467,65 @@ public class CodexDataManager extends SimpleJsonResourceReloadListener {
      * Load DatapackEntry objects from a specific directory by reading actual JSON files
      * This method supports the datapack-driven category system
      */
-    public List<DatapackEntry> loadEntriesFromDirectory(String directory) {
+    public List<DatapackEntry> loadEntriesFromDirectory(ResourceManager resourceManager, String directory) {
         List<DatapackEntry> entries = new ArrayList<>();
-        
+
         try {
             LOGGER.info("Loading entries from directory: {}", directory);
-            
-            // Try to load JSON files from the directory
-            // This is a simplified version - in production you'd use ResourceManager
-            // For now, create entries based on what we know exists
-            String categoryKey = extractCategoryFromPath(directory);
-            entries.addAll(createSampleEntriesForCategory(categoryKey));
-            
+
+            Map<ResourceLocation, Resource> resources = resourceManager.listResources(directory,
+                loc -> loc.getPath().endsWith(".json"));
+
+            for (Map.Entry<ResourceLocation, Resource> resEntry : resources.entrySet()) {
+                ResourceLocation resLoc = resEntry.getKey();
+                if (resLoc.getPath().endsWith("_category.json")) continue;
+
+                try (InputStreamReader reader = new InputStreamReader(resEntry.getValue().open(), StandardCharsets.UTF_8)) {
+                    JsonObject json = GSON.fromJson(reader, JsonObject.class);
+                    if (json == null) continue;
+
+                    String path = resLoc.getPath();
+                    String fileName = path.substring(path.lastIndexOf('/') + 1, path.length() - 5);
+
+                    String title = json.has("title") ? json.get("title").getAsString() : fileName;
+                    String titleKey = json.has("title_key") ? json.get("title_key").getAsString() : fileName;
+
+                    Item icon = Items.BOOK;
+                    if (json.has("icon")) {
+                        ResourceLocation iconLoc = ResourceLocation.tryParse(json.get("icon").getAsString());
+                        if (iconLoc != null) {
+                            Item item = ForgeRegistries.ITEMS.getValue(iconLoc);
+                            if (item != null) icon = item;
+                        }
+                    }
+
+                    DatapackEntry entry = new DatapackEntry(titleKey, title, icon);
+
+                    if (json.has("pages") && json.get("pages").isJsonArray()) {
+                        JsonArray pages = json.getAsJsonArray("pages");
+                        for (JsonElement elem : pages) {
+                            if (!elem.isJsonObject()) continue;
+                            JsonObject pageObj = elem.getAsJsonObject();
+                            String type = pageObj.has("type") ? pageObj.get("type").getAsString() : "text";
+                            String content = pageObj.has("text") ? pageObj.get("text").getAsString() : "";
+                            PageData pageData = new PageData(type, content);
+                            pageData.data = pageObj;
+                            entry.pages.add(pageData);
+                        }
+                    }
+
+                    entries.add(entry);
+                } catch (Exception ex) {
+                    LOGGER.error("Error reading codex entry {}", resLoc, ex);
+                }
+            }
+
             LOGGER.info("Loaded {} entries from {}", entries.size(), directory);
-            
+
         } catch (Exception e) {
             LOGGER.error("Failed to load entries from directory: {}", directory, e);
         }
-        
+
         return entries;
-    }
-    
-    /**
-     * Extract category name from directory path
-     */
-    private String extractCategoryFromPath(String directory) {
-        if (directory.contains("custom_spells")) return "custom_spells";
-        if (directory.contains("community_rituals")) return "community_rituals";  
-        if (directory.contains("expansions")) return "expansions";
-        return "unknown";
-    }
-    
-    /**
-     * Create entries based on the actual JSON files we've created
-     */
-    private List<DatapackEntry> createSampleEntriesForCategory(String categoryKey) {
-        List<DatapackEntry> entries = new ArrayList<>();
-        
-        switch (categoryKey) {
-            case "custom_spells":
-                entries.add(createDatapackEntry("fire_mastery", "Fire Mastery", 
-                    net.minecraft.world.item.Items.FIRE_CHARGE,
-                    "Master the ancient art of fire magic with these powerful techniques.",
-                    "Advanced practitioners can combine fire magic with soul manipulation."));
-                    
-                entries.add(createDatapackEntry("ice_control", "Ice Control",
-                    net.minecraft.world.item.Items.ICE, 
-                    "Harness the power of winter's embrace. Ice magic allows you to freeze enemies.",
-                    "The key to ice magic is understanding that cold is the presence of stillness."));
-                break;
-                
-            case "community_rituals":
-                entries.add(createDatapackEntry("community_summoning", "Community Summoning",
-                    net.minecraft.world.item.Items.BELL,
-                    "When multiple practitioners combine their power, they can achieve impossible feats.",
-                    "The bell serves as both a focus and a timing device for synchronization."));
-                    
-                entries.add(createDatapackEntry("ritual_binding", "Ritual Binding",
-                    net.minecraft.world.item.Items.CHAIN,
-                    "Binding rituals create permanent magical effects that persist across the world.",
-                    "Soul Chains can bind spiritual entities to physical locations."));
-                break;
-                
-            case "expansions":
-                entries.add(createDatapackEntry("expansion_pack", "Expansion Content Pack",
-                    net.minecraft.world.item.Items.END_CRYSTAL,
-                    "This expansion pack contains additional content created by the community.",
-                    "The End Crystal serves as a powerful focus for reality-bending magic."));
-                break;
-        }
-        
-        return entries;
-    }
-    
-    /**
-     * Helper method to create sample entries that match our JSON files
-     */
-    private DatapackEntry createDatapackEntry(String key, String title, Item icon, String... pageTexts) {
-        DatapackEntry entry = new DatapackEntry(key, title, icon);
-        
-        // Add text pages based on the content we have in JSON
-        for (String text : pageTexts) {
-            entry.pages.add(new PageData("text", text));
-        }
-        
-        return entry;
     }
 }


### PR DESCRIPTION
## Summary
- scan ResourceManager for codex entries and build `DatapackEntry` objects from JSON
- discover codex categories dynamically via `_category.json` files
- convert datapack page data with `EidolonPageConverter`

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a71b61e584832794754157ea66c370