### PR TITLE
doc: clarify codex datapack structure

### DIFF
--- a/docs/datapack_overview.md
+++ b/docs/datapack_overview.md
@@ -50,6 +50,17 @@ data/
 
 For more about research entry fields and available gating options, see [research_entries.md](research_entries.md) and [RESEARCH_CONDITIONS.md](RESEARCH_CONDITIONS.md).
 
+### Translation Key Conventions
+
+- Categories: `<namespace>.codex.category.<id>.name`
+- Chapters: `<namespace>.codex.chapter.<id>.title`
+- Entries and page text: `<namespace>.codex.entry.<id>.*`
+
+Keep keys lowercase and namespaced to avoid conflicts. Research chapters
+may optionally gate codex chapters; declare their relationship via the
+research chapter's `category` field and use the `prerequisites` array in
+codex chapter JSON to require specific research IDs.
+
 ## Best Practices
 
 - Use **lowercase IDs** for file names and references.

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
@@ -30,8 +30,16 @@ import java.nio.charset.StandardCharsets;
 import java.util.*;
 
 /**
- * Manages loading and registration of custom codex entries that extend existing Eidolon chapters.
- * This allows addon developers and users to add new entries to existing chapters via JSON files.
+ * Manages loading and registration of custom codex categories, chapters and
+ * entries supplied through datapacks.
+ * <p>
+ * Files follow the format described in {@code docs/datapack_overview.md}:
+ * categories reside in {@code codex_categories/}, chapters in
+ * {@code codex_chapters/} and individual entries in
+ * {@code codex_entries/}. Translation keys should use the pattern
+ * {@code <namespace>.codex.<category>.<chapter>.<suffix>} so that names and
+ * page text can be localised. Research requirements can be declared through
+ * each entry's {@code prerequisites} array.</p>
  */
 @Mod.EventBusSubscriber(modid = EidolonUnchained.MODID, bus = Mod.EventBusSubscriber.Bus.FORGE)
 public class CodexDataManager extends SimpleJsonResourceReloadListener {

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/DatapackCategoryExample.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/DatapackCategoryExample.java
@@ -15,22 +15,36 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * JSON Datapack-driven category creation system
- * 
- * 🔄 CURRENT STATUS: FULLY IMPLEMENTED USING REFLECTION
- * 
- * CURRENT VERSION (0.3.8+): 
- * ✅ Uses reflection to access Eidolon internals
- * ✅ Full JSON datapack functionality enabled
- * ✅ Creates custom categories with chapters from JSON
- * 
- * FUTURE VERSION MIGRATION: When CodexEvents become available:
- * - Replace reflection with direct event API access
- * - Keep all JSON datapack functionality as-is
- * - Simply change internal implementation, not external behavior
- * 
- * DETECTION: Check if class "elucent.eidolon.codex.CodexEvents" exists
- * BENEFIT AFTER MIGRATION: Same functionality, cleaner code, no reflection!
+ * JSON datapack-driven category creation system.
+ *
+ * <p>This example still simulates file loading and uses reflection to
+ * interact with Eidolon internals. The public JSON format is stable and
+ * will be loaded from actual datapack files once a real {@code ResourceManager}
+ * implementation replaces the stubs.</p>
+ *
+ * <p>Final format summary:</p>
+ * <pre>
+ * data/<namespace>/codex/<category>/_category.json
+ * {
+ *   "key": "yourmod.codex.category.magic",
+ *   "name": "yourmod.codex.category.magic.name",
+ *   "icon": "minecraft:book",
+ *   "color": "0x9966FF",
+ *   "description": "Optional description"
+ * }
+ *
+ * data/<namespace>/codex/<category>/<chapter>.json
+ * {
+ *   "title_key": "yourmod.codex.chapter.fire.title",
+ *   "title": "Fire Mastery",          // fallback
+ *   "icon": "minecraft:flint_and_steel",
+ *   "pages": [ { ... page data ... } ]
+ * }
+ * </pre>
+ * Translation keys should follow the pattern
+ * {@code <namespace>.codex.<category>.<chapter>.<suffix>} and research
+ * prerequisites may be supplied via the {@code prerequisites} array inside
+ * each chapter file.</p>
  */
 public class DatapackCategoryExample {
     private static final Logger LOGGER = LogUtils.getLogger();

--- a/src/main/resources/data/eidolonunchained/codex/README.md
+++ b/src/main/resources/data/eidolonunchained/codex/README.md
@@ -38,6 +38,56 @@ Each JSON file defines a chapter with:
 - `crucible`: Crucible processes
 - `list`: Bulleted lists
 - `entity`: Entity information pages
+-
+## 📦 Final JSON Structure
+
+When real file loading is in place, datapacks should mirror the following
+layout:
+
+```text
+data/<namespace>/codex/<category>/_category.json      # Category definition
+data/<namespace>/codex/<category>/<chapter>.json     # Chapter entries
+```
+
+### `_category.json`
+
+```json
+{
+  "key": "yourmod.codex.category.magic",
+  "name": "yourmod.codex.category.magic.name",
+  "icon": "minecraft:book",
+  "color": "0x9966FF",
+  "description": "Optional description",
+  "chapters": ["yourmod:rituals"]
+}
+```
+
+### `<chapter>.json`
+
+```json
+{
+  "title_key": "yourmod.codex.chapter.rituals.title",
+  "title": "Rituals",                 // fallback title
+  "icon": "minecraft:bell",           // optional
+  "prerequisites": ["yourmod:starter_research"],
+  "pages": [ { "type": "text", "content": "..." } ]
+}
+```
+
+### Translation Key Conventions
+
+- Categories: `yourmod.codex.category.<id>.name`
+- Chapters: `yourmod.codex.chapter.<id>.title`
+- Entries and page text: `yourmod.codex.entry.<id>.*`
+
+Place these keys in `assets/<namespace>/lang/<lang>.json`.
+
+### Research Chapters
+
+Codex chapters can be gated behind research. Use the `prerequisites`
+array in chapter JSON to require research IDs. Research chapters reside
+under `data/<namespace>/research_chapters/` and may reference the
+category via their own `category` field.
 
 ## 📝 Example JSON Structure
 


### PR DESCRIPTION
## Summary
- document final JSON layout for category and chapter datapacks
- clarify translation key patterns and research requirements
- refresh comments for datapack category example and data manager

## Testing
- `./gradlew test`

------
https://chatgpt.com/codex/tasks/task_e_68a71b62e02c8327bc443e3c91b4e80b