### PR TITLE
Use fully qualified codex category translation keys

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/CustomCategoryBuilder.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/CustomCategoryBuilder.java
@@ -80,11 +80,14 @@ public class CustomCategoryBuilder {
             entries[i] = new IndexPage.IndexEntry(entry.chapter, entry.icon);
         }
         
+        // Translation key for this category
+        String translationKey = "eidolonunchained.codex.category." + key;
+
         // Create index page
-        Index index = new Index("eidolonunchained.codex.category." + key, new IndexPage(entries));
-        
-        // Create and return category
-        Category category = new Category(key, icon, color, index);
+        Index index = new Index(translationKey, new IndexPage(entries));
+
+        // Create and return category with fully-qualified translation key
+        Category category = new Category(translationKey, icon, color, index);
         
         LOGGER.info("✅ Built category '{}' with {} chapters", key, chapters.size());
         return category;

--- a/src/main/resources/assets/eidolonunchained/lang/en_us.json
+++ b/src/main/resources/assets/eidolonunchained/lang/en_us.json
@@ -1,8 +1,4 @@
 {
-  "eidolon.codex.category.expansions": "Expansions",
-  "eidolon.codex.category.community_rituals": "Community Rituals",
-  "eidolon.codex.category.custom_spells": "Custom Spells",
-  "eidolon.codex.category.advanced_techniques": "Advanced Techniques",
   "eidolonunchained.codex.chapter.community_rituals": "Community Rituals",
   "eidolonunchained.codex.chapter.rituals": "Rituals",
   "eidolonunchained.codex.chapter.summon_ritual": "Summon Ritual",
@@ -137,8 +133,9 @@
   
   "_comment_categories": "Category names for custom sections",
   "eidolonunchained.codex.category.custom_spells": "Custom Spells",
-  "eidolonunchained.codex.category.community_rituals": "Community Rituals", 
+  "eidolonunchained.codex.category.community_rituals": "Community Rituals",
   "eidolonunchained.codex.category.expansions": "Expansions",
+  "eidolonunchained.codex.category.advanced_techniques": "Advanced Techniques",
 
   "_comment_research": "=== Research System Translations ===",
   


### PR DESCRIPTION
## Summary
- remove old `eidolon.codex.category` keys and add missing `advanced_techniques` entry
- pass fully qualified `eidolonunchained.codex.category` translation keys when building categories

## Testing
- `./gradlew build`

------
https://chatgpt.com/codex/tasks/task_e_68a71b5e1f908327b1e331cd7a11085d