### PR TITLE
Use translation keys for codex category names

### DIFF
--- a/docs/DATAPACK_STRUCTURE.md
+++ b/docs/DATAPACK_STRUCTURE.md
@@ -37,6 +37,21 @@ See [Codex Tutorial](codex_tutorial.md) for a guided walkthrough and [Codex Refe
         └── 📄 vanilla_integration.json
 ```
 
+## 🗃️ **Codex Category Template**
+
+```json
+{
+  "key": "community_rituals",
+  "name": "eidolonunchained.codex.category.community_rituals", // translation key
+  "icon": "minecraft:cauldron",
+  "color": "0xCC33FF",
+  "description": "Optional description"
+}
+```
+
+`name` must be the translation key for the category title, following the convention:
+`<namespace>.codex.category.<key>`.
+
 ## 📖 **Codex Entry Template**
 
 ```json

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/DatapackCategoryExample.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/DatapackCategoryExample.java
@@ -85,7 +85,7 @@ public class DatapackCategoryExample {
                 CategoryDefinition categoryDef = loadCategoryDefinition(entry.getValue(), categoryKey);
 
                 if (categoryDef != null) {
-                    LOGGER.info("📁 Found category definition: {}", categoryDef.name);
+                    LOGGER.info("📁 Found category definition: {}", categoryDef.nameKey);
 
                     createCategoryFromDatapack(categories, dataManager,
                         categoryDef.key,
@@ -115,12 +115,14 @@ public class DatapackCategoryExample {
             JsonObject json = new Gson().fromJson(reader, JsonObject.class);
             if (json == null) return null;
 
-            String name = json.has("name") ? json.get("name").getAsString() : categoryKey;
+            String nameKey = json.has("name")
+                ? json.get("name").getAsString()
+                : EidolonUnchained.MODID + ".codex.category." + categoryKey;
             String icon = json.has("icon") ? json.get("icon").getAsString() : "minecraft:book";
             String color = json.has("color") ? json.get("color").getAsString() : "0x555555";
             String description = json.has("description") ? json.get("description").getAsString() : "";
 
-            return new CategoryDefinition(categoryKey, name, icon, color, description);
+            return new CategoryDefinition(categoryKey, nameKey, icon, color, description);
         } catch (Exception e) {
             LOGGER.error("Failed to load category definition for: {}", categoryKey, e);
             return null;
@@ -132,14 +134,14 @@ public class DatapackCategoryExample {
      */
     private static class CategoryDefinition {
         final String key;
-        final String name;
+        final String nameKey;
         final String icon;
         final String color;
         final String description;
-        
-        CategoryDefinition(String key, String name, String icon, String color, String description) {
+
+        CategoryDefinition(String key, String nameKey, String icon, String color, String description) {
             this.key = key;
-            this.name = name;
+            this.nameKey = nameKey;
             this.icon = icon;
             this.color = color;
             this.description = description;

--- a/src/main/resources/data/eidolonunchained/codex/advanced_techniques/_category.json
+++ b/src/main/resources/data/eidolonunchained/codex/advanced_techniques/_category.json
@@ -1,6 +1,6 @@
 {
   "key": "advanced_techniques",
-  "name": "Advanced Techniques",
+  "name": "eidolonunchained.codex.category.advanced_techniques",
   "icon": "eidolon:void_amulet",
   "color": "0x4A0E4E",
   "description": "Master-level techniques that expand upon basic Eidolon knowledge"

--- a/src/main/resources/data/eidolonunchained/codex/community_rituals/_category.json
+++ b/src/main/resources/data/eidolonunchained/codex/community_rituals/_category.json
@@ -1,6 +1,6 @@
 {
   "key": "community_rituals",
-  "name": "Community Rituals", 
+  "name": "eidolonunchained.codex.category.community_rituals",
   "icon": "minecraft:cauldron",
   "color": "0xCC33FF",
   "description": "Collaborative magical workings that require multiple practitioners"

--- a/src/main/resources/data/eidolonunchained/codex/custom_spells/_category.json
+++ b/src/main/resources/data/eidolonunchained/codex/custom_spells/_category.json
@@ -1,6 +1,6 @@
 {
   "key": "custom_spells",
-  "name": "Custom Spells",
+  "name": "eidolonunchained.codex.category.custom_spells",
   "icon": "minecraft:enchanted_book", 
   "color": "0x4169E1",
   "description": "Community-created magical techniques and spell combinations"

--- a/src/main/resources/data/eidolonunchained/codex/expansions/_category.json
+++ b/src/main/resources/data/eidolonunchained/codex/expansions/_category.json
@@ -1,6 +1,6 @@
 {
   "key": "expansions",
-  "name": "Expansions",
+  "name": "eidolonunchained.codex.category.expansions",
   "icon": "minecraft:end_crystal",
   "color": "0x9966FF", 
   "description": "Additional content packs and expansion modules"


### PR DESCRIPTION
## Summary
- Reference translation keys in `_category.json` files instead of hardcoded titles
- Document category `name` translation key convention in DATAPACK_STRUCTURE.md
- Resolve `name` as a translation key when loading category definitions

## Testing
- `./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a7232a009c832780e44c70b1169607