### PR TITLE
Use translation keys for custom codex chapters

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
@@ -314,7 +314,7 @@ public class CodexDataManager extends SimpleJsonResourceReloadListener {
                         return;
                     }
 
-                    String titleStr = json.get("title").getAsString();
+                    String titleKey = json.get("title").getAsString();
                     String iconStr = json.has("icon") ? json.get("icon").getAsString() : "minecraft:book";
                     ResourceLocation icon = ResourceLocation.tryParse(iconStr);
 
@@ -322,12 +322,9 @@ public class CodexDataManager extends SimpleJsonResourceReloadListener {
                     path = path.substring("codex_chapters/".length(), path.length() - 5); // remove directory and .json
                     ResourceLocation chapterId = new ResourceLocation(resLoc.getNamespace(), path);
 
-                    // Store the translation key or literal for the chapter title
-                    String chapterTitle = (titleStr.contains(".") || titleStr.startsWith("eidolonunchained:"))
-                        ? Component.translatable(titleStr).getString()
-                        : titleStr;
+                    Component chapterTitle = Component.translatable(titleKey);
 
-                    LOGGER.info("Registering custom chapter: {} (title: {}, icon: {})", chapterId, chapterTitle, icon);
+                    LOGGER.info("Registering custom chapter: {} (title: {}, icon: {})", chapterId, chapterTitle.getString(), icon);
                     CUSTOM_CHAPTERS.put(chapterId, new ChapterDefinition(chapterTitle, icon));
                     LOGGER.info("Loaded custom chapter definition {}", chapterId);
                 } catch (IOException e) {
@@ -415,15 +412,15 @@ public class CodexDataManager extends SimpleJsonResourceReloadListener {
      * Represents a datapack-defined chapter with title and icon
      */
     public static class ChapterDefinition {
-        private final String title;
+        private final Component title;
         private final ResourceLocation icon;
 
-        public ChapterDefinition(String title, ResourceLocation icon) {
+        public ChapterDefinition(Component title, ResourceLocation icon) {
             this.title = title;
             this.icon = icon;
         }
 
-        public String getTitle() {
+        public Component getTitle() {
             return title;
         }
 

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonCodexIntegration.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonCodexIntegration.java
@@ -81,7 +81,7 @@ public class EidolonCodexIntegration {
 
             String title;
             if (metadata != null) {
-                title = metadata.getTitle();
+                title = metadata.getTitle().getString();
             } else if (research != null) {
                 title = research.getTitle().getString();
             } else {

--- a/src/main/resources/data/eidolonunchained/codex_chapters/community_rituals.json
+++ b/src/main/resources/data/eidolonunchained/codex_chapters/community_rituals.json
@@ -1,4 +1,4 @@
 {
-  "title": "Community Rituals",
+  "title": "eidolonunchained.codex.chapter.community_rituals",
   "icon": "minecraft:book"
 }

--- a/src/main/resources/data/eidolonunchained/codex_chapters/rituals.json
+++ b/src/main/resources/data/eidolonunchained/codex_chapters/rituals.json
@@ -1,4 +1,4 @@
 {
-  "title": "Rituals",
+  "title": "eidolonunchained.codex.chapter.rituals",
   "icon": "minecraft:enchanting_table"
 }

--- a/src/main/resources/data/eidolonunchained/codex_chapters/summon_ritual.json
+++ b/src/main/resources/data/eidolonunchained/codex_chapters/summon_ritual.json
@@ -1,4 +1,4 @@
 {
-  "title": "Summoning Rituals",
+  "title": "eidolonunchained.codex.chapter.summon_ritual",
   "icon": "minecraft:end_crystal"
 }


### PR DESCRIPTION
## Summary
- replace hardcoded chapter titles with translation keys
- resolve custom chapter titles via `Component.translatable` and store as components

## Testing
- `PATH=/usr/bin:/bin ./gradlew build`


------
https://chatgpt.com/codex/tasks/task_e_68a723297b248327bb575da46d3eb235