### PR TITLE
Handle colon-based translation keys

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
@@ -204,11 +204,11 @@ public class CodexDataManager extends SimpleJsonResourceReloadListener {
 
             // Basic fields
             String titleStr = json.has("title") ? json.get("title").getAsString() : location.getPath();
-            Component title = (titleStr.contains(".") || titleStr.startsWith("eidolonunchained:"))
+            Component title = (titleStr.contains(":") || titleStr.contains(".") || titleStr.startsWith("eidolonunchained:"))
                 ? Component.translatable(titleStr)
                 : Component.literal(titleStr);
             String descStr = json.has("description") ? json.get("description").getAsString() : "";
-            Component description = (descStr.contains(".") || descStr.startsWith("eidolonunchained:"))
+            Component description = (descStr.contains(":") || descStr.contains(".") || descStr.startsWith("eidolonunchained:"))
                 ? Component.translatable(descStr)
                 : Component.literal(descStr);
 
@@ -323,7 +323,7 @@ public class CodexDataManager extends SimpleJsonResourceReloadListener {
                     ResourceLocation chapterId = new ResourceLocation(resLoc.getNamespace(), path);
 
                     // Store the translation key or literal for the chapter title
-                    String chapterTitle = (titleStr.contains(".") || titleStr.startsWith("eidolonunchained:"))
+                    String chapterTitle = (titleStr.contains(":") || titleStr.contains(".") || titleStr.startsWith("eidolonunchained:"))
                         ? Component.translatable(titleStr).getString()
                         : titleStr;
 

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/ResearchDataManager.java
@@ -191,11 +191,11 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
 
             ResourceLocation chapterId = ResourceLocation.tryParse(json.get("id").getAsString());
             String titleStr = json.has("title") ? json.get("title").getAsString() : chapterId.getPath();
-            Component title = (titleStr.contains(".") || titleStr.startsWith("eidolonunchained:"))
+            Component title = (titleStr.contains(":") || titleStr.contains(".") || titleStr.startsWith("eidolonunchained:"))
                 ? Component.translatable(titleStr)
                 : Component.literal(titleStr);
             String descStr = json.has("description") ? json.get("description").getAsString() : "";
-            Component description = (descStr.contains(".") || descStr.startsWith("eidolonunchained:"))
+            Component description = (descStr.contains(":") || descStr.contains(".") || descStr.startsWith("eidolonunchained:"))
                 ? Component.translatable(descStr)
                 : Component.literal(descStr);
 
@@ -259,12 +259,12 @@ public class ResearchDataManager extends SimpleJsonResourceReloadListener {
 
             // Basic fields
             String titleStr = json.has("title") ? json.get("title").getAsString() : entryId.toString();
-            Component title = (titleStr.contains(".") || titleStr.startsWith("eidolonunchained:"))
+            Component title = (titleStr.contains(":") || titleStr.contains(".") || titleStr.startsWith("eidolonunchained:"))
                 ? Component.translatable(titleStr)
                 : Component.literal(titleStr);
 
             String descStr = json.has("description") ? json.get("description").getAsString() : "";
-            Component description = (descStr.contains(".") || descStr.startsWith("eidolonunchained:"))
+            Component description = (descStr.contains(":") || descStr.contains(".") || descStr.startsWith("eidolonunchained:"))
                 ? Component.translatable(descStr)
                 : Component.literal(descStr);
 

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonPageConverter.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonPageConverter.java
@@ -120,6 +120,21 @@ public class EidolonPageConverter {
      * Translate text if it's a translation key, otherwise return as-is
      */
     private static String translateText(String text) {
+        // If text contains a namespace, treat it as a translation key
+        if (text.contains(":")) {
+            LOGGER.info("[DEBUG] Requested translation for key: {}", text);
+            try {
+                String result = Component.translatable(text).getString();
+                LOGGER.info("[DEBUG] Component translation attempt: '{}' -> '{}'", text, result);
+                if (!result.equals(text) && !result.contains("translation.key.not.found")) {
+                    return result;
+                }
+            } catch (Exception e) {
+                LOGGER.info("[DEBUG] Component translation failed for: {}, error: {}", text, e.getMessage());
+            }
+            return text;
+        }
+
         // If text looks like a translation key (contains dots and starts with mod name)
         if (text.contains(".") && (text.startsWith("eidolonunchained.") || text.startsWith("eidolon."))) {
             LOGGER.info("[DEBUG] Requested translation for key: {}", text);


### PR DESCRIPTION
## Summary
- Translate strings containing ':' in codex and research data before falling back to literal text
- Check for namespace-based keys during page conversion and attempt `Component.translatable`

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a7232efd348327b42a26cda49d8278