### PR TITLE
Handle component chapter titles

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
@@ -322,9 +322,12 @@ public class CodexDataManager extends SimpleJsonResourceReloadListener {
                     path = path.substring("codex_chapters/".length(), path.length() - 5); // remove directory and .json
                     ResourceLocation chapterId = new ResourceLocation(resLoc.getNamespace(), path);
 
-                    Component chapterTitle = Component.translatable(titleKey);
+                    Component chapterTitle =
+                        (titleKey.contains(":") || titleKey.contains("."))
+                            ? Component.translatable(titleKey)
+                            : Component.literal(titleKey);
 
-                    LOGGER.info("Registering custom chapter: {} (title: {}, icon: {})", chapterId, chapterTitle.getString(), icon);
+                    LOGGER.info("Registering custom chapter: {} (title: {}, icon: {})", chapterId, chapterTitle, icon);
                     CUSTOM_CHAPTERS.put(chapterId, new ChapterDefinition(chapterTitle, icon));
                     LOGGER.info("Loaded custom chapter definition {}", chapterId);
                 } catch (IOException e) {

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonCodexIntegration.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonCodexIntegration.java
@@ -12,6 +12,7 @@ import elucent.eidolon.codex.Page;
 import elucent.eidolon.codex.TextPage;
 import elucent.eidolon.codex.TitlePage;
 import elucent.eidolon.registries.Researches;
+import net.minecraft.network.chat.Component;
 import net.minecraft.resources.ResourceLocation;
 import net.minecraftforge.eventbus.api.SubscribeEvent;
 import net.minecraftforge.fml.common.Mod;
@@ -79,20 +80,21 @@ public class EidolonCodexIntegration {
             ResearchChapter research = ResearchDataManager.getResearchChapter(chapterId);
             CodexDataManager.ChapterDefinition metadata = CodexDataManager.getCustomChapter(chapterId);
 
-            String title;
+            Component title;
             if (metadata != null) {
-                title = metadata.getTitle().getString();
+                title = metadata.getTitle();
             } else if (research != null) {
-                title = research.getTitle().getString();
+                title = research.getTitle();
             } else {
-                title = chapterId.getPath();
+                title = Component.literal(chapterId.getPath());
             }
 
             if (research == null) {
                 LOGGER.info("No research chapter for {} - using fallback metadata", chapterId);
             }
 
-            Chapter chapter = new Chapter(title, new TitlePage(title));
+            String renderedTitle = title.getString();
+            Chapter chapter = new Chapter(renderedTitle, new TitlePage(renderedTitle));
             LOGGER.info("Created chapter {} for codex integration", chapterId);
 
             LOGGER.info("✓ Injecting {} entries into chapter {}", entries.size(), chapterId);


### PR DESCRIPTION
## Summary
- Create components for custom codex chapter titles, using translation keys only when appropriate
- Integrate chapter titles as `Component` objects and render them only when building UI

## Testing
- `./gradlew test`


------
https://chatgpt.com/codex/tasks/task_e_68a73503a9b4832786794c5b679758d0