### PR TITLE
docs: add datapack structure guide

### DIFF
--- a/docs/datapack/structure.md
+++ b/docs/datapack/structure.md
@@ -1,0 +1,37 @@
+# 📁 Datapack Structure
+
+Eidolon Unchained datapacks follow the standard Minecraft pack layout.  The `data/` folder
+contains gameplay JSON while `assets/` stores language and other client resources.
+
+## `data/`
+
+```text
+📦 data/
+└── 📁 eidolonunchained/                # Your namespace
+    ├── 📁 codex_chapters/              # Optional new chapter definitions
+    │   └── 📄 mythology.json           # Example chapter file
+    ├── 📁 codex_entries/               # 📖 Codex pages live here
+    │   └── 📄 ritual_mastery.json      # Example codex entry
+    └── 📁 research_entries/            # 🔬 Research nodes live here
+        └── 📄 ritual_master.json       # Example research entry
+```
+
+*`codex_entries/` and `research_entries/` hold the JSON that adds new pages and
+progression to the mod.*
+
+## `assets/`
+
+```text
+📦 assets/
+└── 📁 eidolonunchained/                # Same namespace as above
+    └── 📁 lang/
+        └── 📄 en_us.json               # Translation keys for codex & research
+```
+
+Put any additional textures, models, or sounds under `assets/<namespace>/` as needed.
+Translation keys referenced by your codex and research files belong in the language
+JSON shown above.
+
+For more detailed explanations of the JSON formats see:
+- [Codex Reference](../codex_reference.md)
+- [Research Entries](../research_entries.md)


### PR DESCRIPTION
## Summary
- document example layout for data/ and assets/ folders
- highlight where codex and research JSON files belong

## Testing
- `./gradlew build` *(fails: cannot find symbol `getString` in EidolonCodexIntegration.java)*


------
https://chatgpt.com/codex/tasks/task_e_68a7434826b88327a00eabdcd96919ea