### PR TITLE
docs: add UI texture customization guide

### DIFF
--- a/docs/misc/ui_texture_customization.md
+++ b/docs/misc/ui_texture_customization.md
@@ -1,0 +1,34 @@
+# UI Texture Customization
+
+Eidolon Unchained's user interface textures live under `assets/eidolon/textures/gui/`. Any file in that directory can be replaced by a resource pack by providing a texture with the same path and name.
+
+## Default texture locations
+
+Some common UI textures include:
+
+- `assets/eidolon/textures/gui/mana_bar.png` – mana bar shown on the HUD.
+- `assets/eidolon/textures/gui/codex_bg.png` – background for the Codex interface.
+
+## Overriding textures in a resource pack
+
+Create a resource pack with the same folder structure. Place your replacement PNGs in the `assets/eidolon/textures/gui/` directory of the pack.
+
+```text
+MyPack/
+  pack.mcmeta
+  assets/
+    eidolon/
+      textures/
+        gui/
+          mana_bar.png       # replaces the default mana bar
+          codex_bg.png       # replaces the Codex background
+```
+
+## Before/after examples
+
+| Default file path                                  | Override inside your pack                                           |
+|----------------------------------------------------|---------------------------------------------------------------------|
+| `assets/eidolon/textures/gui/mana_bar.png`         | `MyPack/assets/eidolon/textures/gui/mana_bar.png`                   |
+| `assets/eidolon/textures/gui/codex_bg.png`         | `MyPack/assets/eidolon/textures/gui/codex_bg.png`                   |
+
+Reload resource packs in game (`F3+T`) to see changes. Keep the same image dimensions as the originals to avoid stretching or misalignment.


### PR DESCRIPTION
## Summary
- document locations of default GUI textures
- show how to override textures in a resource pack with before/after file paths

## Testing
- `./gradlew build` *(fails: cannot find symbol getString)*

------
https://chatgpt.com/codex/tasks/task_e_68a7434d67248327a47d7aecf7895595