### PR TITLE
Use translation keys in codex example entry

### DIFF
--- a/docs/codex/example_entry.json
+++ b/docs/codex/example_entry.json
@@ -1,0 +1,31 @@
+{
+  "title": "eidolonunchained.codex.entry.shadow_manipulation.title",
+  "icon": "minecraft:coal_block",
+  "target_chapter": "rituals",
+  "pages": [
+    {
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.shadow_manipulation.intro"
+    },
+    {
+      "type": "crafting_recipe",
+      "recipe": "eidolonunchained:shadow_crystal",
+      "text": "eidolonunchained.codex.entry.shadow_manipulation.shadow_crystal"
+    },
+    {
+      "type": "ritual_recipe",
+      "ritual": "eidolonunchained:shadow_bind",
+      "text": "eidolonunchained.codex.entry.shadow_manipulation.shadow_bind"
+    },
+    {
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.shadow_manipulation.warning"
+    },
+    {
+      "type": "image",
+      "image": "eidolonunchained:textures/gui/codex/shadow_diagram.png",
+      "width": 128,
+      "height": 96
+    }
+  ]
+}

--- a/docs/codex/example_entry.md
+++ b/docs/codex/example_entry.md
@@ -1,0 +1,16 @@
+# Example Codex Entry with Translation Keys
+
+This example demonstrates how codex JSON files reference translations.  
+All user-facing strings are defined with namespaced keys following the pattern:
+
+```
+<namespace>.codex.entry.<entry_id>.<section>
+```
+
+For the shadow manipulation entry, the JSON uses keys like
+`eidolonunchained.codex.entry.shadow_manipulation.title` and
+`eidolonunchained.codex.entry.shadow_manipulation.intro`.
+
+Add the corresponding text to the language file:
+`src/main/resources/assets/eidolonunchained/lang/en_us.json`.
+When the game loads, these keys resolve to the localized strings.

--- a/src/main/resources/assets/eidolonunchained/lang/en_us.json
+++ b/src/main/resources/assets/eidolonunchained/lang/en_us.json
@@ -121,6 +121,12 @@
   "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.purification_effects": "Purification Effects: Active sacred signs cleanse nearby areas of corruption and negative energy. Undead creatures suffer damage when approaching these blessed inscriptions.",
   "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.protective_properties": "Protective Properties: Sacred signs create auras of divine protection that strengthen allies and weaken enemies aligned with darkness. These effects are most powerful during daylight hours and holy celebrations.",
 
+  "eidolonunchained.codex.entry.shadow_manipulation.title": "Shadow Manipulation",
+  "eidolonunchained.codex.entry.shadow_manipulation.intro": "Shadow manipulation is an advanced magical technique that allows practitioners to bend darkness to their will. This ancient art requires both mental discipline and a deep understanding of the void.",
+  "eidolonunchained.codex.entry.shadow_manipulation.shadow_crystal": "The Shadow Crystal serves as a focus for shadow-based spells. Its dark surface seems to absorb light itself.",
+  "eidolonunchained.codex.entry.shadow_manipulation.shadow_bind": "The Shadow Bind ritual allows you to temporarily merge with your own shadow, becoming incorporeal for a brief time.",
+  "eidolonunchained.codex.entry.shadow_manipulation.warning": "§4Warning:§r Prolonged use of shadow magic can lead to permanent changes in one's essence. Practice with caution and always maintain a connection to the light.",
+
   "_comment": "=== Custom Category Translations ===",
   
   "eidolonunchained.codex.custom_spells.fire_mastery.title": "Fire Mastery",


### PR DESCRIPTION
## Summary
- Document translation-key usage for shadow manipulation example
- Provide localized strings via `en_us.json`

## Testing
- `jq . docs/codex/example_entry.json`
- `jq . src/main/resources/assets/eidolonunchained/lang/en_us.json`
- `python - <<'PY' ...` *(translation resolution)*
- `./gradlew build` *(fails: cannot find symbol getString)*

------
https://chatgpt.com/codex/tasks/task_e_68a746d92c9c83279551fba989dba66d