### PR TITLE
Clarify codex and research directory structure

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,6 +66,10 @@ For a step-by-step tutorial see [Codex Tutorial](docs/codex_tutorial.md). For a 
 
 #### 1. JSON Entry Structure
 Create JSON files in `src/main/resources/data/eidolonunchained/codex_entries/`:
+These files add pages to the existing codex categories.
+To introduce a brand new category, make a folder under
+`src/main/resources/data/eidolonunchained/codex/` with a `_category.json`
+and place the category's entry files inside it.
 
 ```json
 {

--- a/docs/datapack/overview.md
+++ b/docs/datapack/overview.md
@@ -4,9 +4,12 @@ All paths below are relative to the repository root.
 
 ## Directory Structure
 
-- `src/main/resources/data/eidolonunchained/codex/<category>/_category.json` – defines a codex category.
+- `src/main/resources/data/eidolonunchained/codex/<category>/_category.json` – defines a **custom** codex category.
+- `src/main/resources/data/eidolonunchained/codex/<category>/<entry>.json` – entry file that lives inside that custom category.
+- `src/main/resources/data/eidolonunchained/codex_entries/<entry>.json` – adds a page to one of the **built-in** categories. Organize these files in subfolders as desired; the category is determined by `target_chapter`.
 - `src/main/resources/data/eidolonunchained/codex_chapters/<chapter>.json` – declares a chapter that entries can target.
-- `src/main/resources/data/eidolonunchained/codex/<category>/<entry>.json` – codex entry file representing a page within the category. Each entry specifies `target_chapter` to link to a chapter and provides page content via its `pages` array.
+
+Research uses a parallel structure with `research_chapters/` and `research_entries/`.
 
 ## Example
 

--- a/docs/datapack/structure.md
+++ b/docs/datapack/structure.md
@@ -8,16 +8,24 @@ contains gameplay JSON while `assets/` stores language and other client resource
 ```text
 📦 data/
 └── 📁 eidolonunchained/                # Your namespace
-    ├── 📁 codex_chapters/              # Optional new chapter definitions
-    │   └── 📄 mythology.json           # Example chapter file
-    ├── 📁 codex_entries/               # 📖 Codex pages live here
+    ├── 📁 codex/                       # Category folders for new codex tabs
+    │   └── 📁 custom_spells/           # Example category folder
+    │       ├── 📄 _category.json       # Category metadata
+    │       └── 📄 fire_mastery.json    # Example entry inside the category
+    ├── 📁 codex_entries/               # 📖 Pages for built-in categories
     │   └── 📄 ritual_mastery.json      # Example codex entry
+    ├── 📁 codex_chapters/              # Optional codex chapter definitions
+    │   └── 📄 mythology.json           # Example chapter file
+    ├── 📁 research_chapters/           # Optional research chapter definitions
+    │   └── 📄 void_alchemy.json        # Example research chapter
     └── 📁 research_entries/            # 🔬 Research nodes live here
         └── 📄 ritual_master.json       # Example research entry
 ```
 
-*`codex_entries/` and `research_entries/` hold the JSON that adds new pages and
-progression to the mod.*
+*Use `codex_entries/` to add pages to existing categories.  Place new categories
+and their entries under `codex/` in folders with a `_category.json` file.
+`research_entries/` hold individual research nodes, while `research_chapters/`
+define the chapters that group them.*
 
 ## `assets/`
 


### PR DESCRIPTION
## Summary
- detail codex/ and codex_entries/ usage in datapack structure and overview docs
- document research_chapters/ alongside research_entries/
- note distinction between existing and custom categories in README

## Testing
- `./gradlew test` *(fails: cannot find symbol getString in EidolonCodexIntegration.java)*

------
https://chatgpt.com/codex/tasks/task_e_68a766de115c83278dfd053bfed2c48d