### PR TITLE
docs: document item_showcase codex page type

### DIFF
--- a/docs/codex/reference.md
+++ b/docs/codex/reference.md
@@ -53,6 +53,17 @@ Displays a paragraph of text.
 ```
 Shows a bullet list of strings.
 
+### `item_showcase`
+```
+{
+  "type": "item_showcase",
+  "title": "Chainmail Properties",
+  "item": "eidolon:warped_sprouts",
+  "text": "Chainmail reinforced with magical wards offers superior protection."
+}
+```
+Highlights a single item with a title and descriptive text. The Warded Mail entry (`equipment/warded_mail.json`) uses this format to showcase the enchanted chainmail.
+
 ### `crafting`
 ```
 {


### PR DESCRIPTION
## Summary
- document `item_showcase` codex page with title, item, and text fields
- illustrate usage with example from `equipment/warded_mail.json`

## Testing
- `./gradlew test` *(fails: cannot find symbol getString)*

------
https://chatgpt.com/codex/tasks/task_e_68a766df6f848327ad9318abeb480d13