### PR TITLE
Add new codex page types and remove smelting support

### DIFF
--- a/docs/codex/reference.md
+++ b/docs/codex/reference.md
@@ -141,4 +141,10 @@ References a predefined ritual by ID.
 ```
 Embeds a texture into the page.
 
+### `item_showcase`
+```
+{ "type": "item_showcase", "title": "Arcane Alloy", "item": "eidolon:arcane_gold_ingot", "text": "A gleaming ingot brimming with latent power." }
+```
+Displays a single item with a title and description.
+
 These examples are pulled directly from the sample codex data shipped with the project and represent the currently supported page types.

--- a/docs/misc/system_summary.md
+++ b/docs/misc/system_summary.md
@@ -6,7 +6,7 @@ The codex extension system lets datapacks add custom knowledge entries to Eidolo
 ## Current Metrics
 - **Codex entries**: 56 JSON files loaded from `data/eidolonunchained/codex_entries` and `data/eidolonunchained/codex`.
 - **Chapters**: Content spans 10 chapters (8 base Eidolon chapters plus 2 custom mod chapters; a third custom chapter is available for future use).
-- **Supported page types**: 9 – `text`, `title`, `entity`, `crafting`, `ritual`, `crucible`, `list`, `smelting`, and `workbench`.
+- **Supported page types**: 12 – `text`, `title`, `entity`, `crafting`, `crafting_recipe`, `ritual`, `ritual_recipe`, `crucible`, `list`, `image`, `item_showcase`, and `workbench`.
 
 ## Example Entry
 ```json
@@ -16,7 +16,7 @@ The codex extension system lets datapacks add custom knowledge entries to Eidolo
   "icon": "eidolon:arcane_gold_ingot",
   "pages": [
     { "type": "text", "text": "Transmuted metal infused with void energy." },
-    { "type": "smelting", "input": "minecraft:gold_ingot", "result": "eidolon:arcane_gold_ingot" }
+    { "type": "crafting_recipe", "recipe": "eidolon:arcane_gold_ingot" }
   ]
 }
 ```

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/codex/CodexEntry.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/codex/CodexEntry.java
@@ -30,10 +30,13 @@ public class CodexEntry {
         RITUAL("ritual"),
         ENTITY("entity"),
         CRAFTING("crafting"),
-        SMELTING("smelting"),
         CRUCIBLE("crucible"),
         WORKBENCH("workbench"),
-        LIST("list");
+        LIST("list"),
+        CRAFTING_RECIPE("crafting_recipe"),
+        RITUAL_RECIPE("ritual_recipe"),
+        IMAGE("image"),
+        ITEM_SHOWCASE("item_showcase");
 
         private final String name;
 


### PR DESCRIPTION
## Summary
- support `crafting_recipe`, `ritual_recipe`, `image`, and `item_showcase` pages
- drop obsolete `smelting` page type
- document expanded page type list

## Testing
- `./gradlew build` *(fails: Stopping at requested step: .../rename/output.jar)*

------
https://chatgpt.com/codex/tasks/task_e_68a77f095b908327b19905e746149eff