### PR TITLE
Expand codex entry types

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/codex/CodexEntry.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/codex/CodexEntry.java
@@ -26,14 +26,14 @@ public class CodexEntry {
 
     public enum EntryType {
         TEXT("text"),
-        RECIPE("recipe"),
-        RITUAL("ritual"),
+        TITLE("title"),
         ENTITY("entity"),
         CRAFTING("crafting"),
-        SMELTING("smelting"),
+        RITUAL("ritual"),
         CRUCIBLE("crucible"),
-        WORKBENCH("workbench"),
-        LIST("list");
+        LIST("list"),
+        SMELTING("smelting"),
+        WORKBENCH("workbench");
 
         private final String name;
 
@@ -43,6 +43,18 @@ public class CodexEntry {
 
         public String getName() {
             return name;
+        }
+
+        /**
+         * Get an EntryType by its string name, or null if unrecognized.
+         */
+        public static EntryType fromName(String name) {
+            for (EntryType type : values()) {
+                if (type.name.equalsIgnoreCase(name)) {
+                    return type;
+                }
+            }
+            return null;
         }
     }
 

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/data/CodexDataManager.java
@@ -264,11 +264,11 @@ public class CodexDataManager extends SimpleJsonResourceReloadListener {
             CodexEntry.EntryType type = CodexEntry.EntryType.TEXT;
             if (json.has("type")) {
                 String typeStr = json.get("type").getAsString();
-                for (CodexEntry.EntryType t : CodexEntry.EntryType.values()) {
-                    if (t.getName().equalsIgnoreCase(typeStr)) {
-                        type = t;
-                        break;
-                    }
+                CodexEntry.EntryType parsed = CodexEntry.EntryType.fromName(typeStr);
+                if (parsed != null) {
+                    type = parsed;
+                } else {
+                    LOGGER.warn("Unknown codex entry type '{}' in {}, defaulting to TEXT", typeStr, entryId);
                 }
             }
 


### PR DESCRIPTION
## Summary
- support new codex page types including title pages
- warn when datapack entries specify unknown page types

## Testing
- `./gradlew test` *(fails: cannot find symbol `getString` in `EidolonCodexIntegration`)*

------
https://chatgpt.com/codex/tasks/task_e_68a77f2313608327b8ddc9ccc9368ae2