### PR TITLE
Handle object recipes in crafting page

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonPageConverter.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonPageConverter.java
@@ -1,6 +1,7 @@
 package com.bluelotuscoding.eidolonunchained.integration;
 
 import com.google.gson.JsonArray;
+import com.google.gson.JsonElement;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.mojang.logging.LogUtils;
@@ -277,7 +278,12 @@ public class EidolonPageConverter {
         // Support both "recipe" and "item" properties
         String itemId = "";
         if (pageJson.has("recipe")) {
-            itemId = pageJson.get("recipe").getAsString();
+            JsonElement recipeElement = pageJson.get("recipe");
+            if (recipeElement.isJsonObject()) {
+                LOGGER.error("Crafting page 'recipe' must be a string recipe ID, not a JSON object");
+                return createFallbackTextPage(pageJson);
+            }
+            itemId = recipeElement.getAsString();
             LOGGER.info("Creating crafting page for recipe: {}", itemId);
         } else if (pageJson.has("item")) {
             itemId = pageJson.get("item").getAsString();

--- a/src/main/resources/data/eidolonunchained/codex_entries/equipment/warded_mail.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/equipment/warded_mail.json
@@ -9,30 +9,15 @@
     {
   "type": "item_showcase",
   "title": "Chainmail Properties",
-  "item": "eidolon:warped_sprouts",
+  "item": "eidolon:warded_mail",
   "text": "Chainmail reinforced with magical wards offers superior protection."
     },
     {
   "type": "crafting",
   "title": "Crafting Warded Mail",
-  "recipe": {
-        "type": "minecraft:crafting_shaped",
-        "pattern": [
-          "SAS",
-          "ACA",
-          "SAS"
-        ],
-        "key": {
-          "S": {"item": "eidolon:silver_ingot"},
-          "A": {"item": "minecraft:chainmail_chestplate"},
-          "C": {"item": "eidolon:soul_shard"}
-        },
-        "result": {
-          "item": "eidolon:warped_sprouts",
-          "count": 1
-        }
-      },
+  "recipe": "eidolon:warded_mail",
   "text": "Crafting warded mail requires rare materials and precise technique."
     }
   ]
 }
+


### PR DESCRIPTION
## Summary
- guard against inline recipe objects in crafting page conversion
- update warded mail codex entry to use a recipe id and correct item showcase

## Testing
- ⚠️ `./gradlew test` *(fails: cannot find symbol getString in EidolonCodexIntegration.java)*

------
https://chatgpt.com/codex/tasks/task_e_68a77f365448832794575e00a7173ca7