### PR TITLE
Use TitledRitualPage for ritual pages with titles

### DIFF
--- a/docs/codex/reference.md
+++ b/docs/codex/reference.md
@@ -89,21 +89,13 @@ Specialized recipe page for crucible crafting.
 ```
 {
   "type": "ritual",
-  "content": "Greater Summoning Circle",
-  "data": {
-    "circle_size": 5,
-    "participants": 3,
-    "components": [
-      {"item": "minecraft:bell", "count": 1},
-      {"item": "minecraft:soul_sand", "count": 32},
-      {"item": "minecraft:wither_skeleton_skull", "count": 3},
-      {"item": "minecraft:nether_star", "count": 1}
-    ],
-    "description": "Summons a powerful ally to aid the community"
-  }
+  "ritual": "eidolon:crystallization",
+  "text": "eidolonunchained.codex.page.crystal_ritual"
 }
 ```
-Shows a top‑down ritual circle with components.
+Shows a top‑down ritual circle for the specified ritual. The `text` field is a
+translation key base; the game will automatically append `.title` when looking
+up the display title.
 
 ### `workbench`
 ```

--- a/docs/codex/tutorial.md
+++ b/docs/codex/tutorial.md
@@ -13,7 +13,7 @@ Path: `data/eidolonunchained/codex_entries/rituals/advanced_wraith_summoning.jso
   "icon": { "item": "eidolon:wraith_spawn_egg" },
   "pages": [
     { "type": "text", "text": "eidolonunchained.codex.entry.advanced_wraith_summoning.intro" },
-    { "type": "ritual", "ritual": "eidolonunchained:advanced_wraith_summoning" }
+    { "type": "ritual", "ritual": "eidolonunchained:advanced_wraith_summoning", "text": "eidolonunchained.codex.entry.advanced_wraith_summoning.ritual" }
   ]
 }
 ```
@@ -25,7 +25,8 @@ Path: `assets/eidolonunchained/lang/en_us.json`
 ```json
 {
   "eidolonunchained.codex.entry.advanced_wraith_summoning.title": "Advanced Wraith Summoning",
-  "eidolonunchained.codex.entry.advanced_wraith_summoning.intro": "Bind wraiths with refined ritual techniques."
+  "eidolonunchained.codex.entry.advanced_wraith_summoning.intro": "Bind wraiths with refined ritual techniques.",
+  "eidolonunchained.codex.entry.advanced_wraith_summoning.ritual.title": "Advanced Wraith Summoning Ritual"
 }
 ```
 

--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonPageConverter.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonPageConverter.java
@@ -9,7 +9,7 @@ import elucent.eidolon.codex.CruciblePage;
 import elucent.eidolon.codex.EntityPage;
 import elucent.eidolon.codex.ListPage;
 import elucent.eidolon.codex.Page;
-import elucent.eidolon.codex.RitualPage;
+import elucent.eidolon.codex.TitledRitualPage;
 import elucent.eidolon.codex.SmeltingPage;
 import elucent.eidolon.codex.TextPage;
 import elucent.eidolon.codex.TitlePage;
@@ -383,8 +383,15 @@ public class EidolonPageConverter {
             return createFallbackTextPage(pageJson);
         }
 
-        // Create RitualPage with ResourceLocation parameter
-        return new RitualPage(ritualResource);
+        // Use TitledRitualPage with a title translation key
+        String title = pageJson.has("text") ? pageJson.get("text").getAsString() : "";
+        if (title.isEmpty()) {
+            LOGGER.warn("Ritual page missing title text");
+            return createFallbackTextPage(pageJson);
+        }
+
+        // Create TitledRitualPage with translation key and ritual ID
+        return new TitledRitualPage(title, ritualResource);
     }
 
     /**

--- a/src/main/resources/data/eidolonunchained/codex/README.md
+++ b/src/main/resources/data/eidolonunchained/codex/README.md
@@ -155,16 +155,13 @@ Use any Minecraft item ID:
 ```
 
 ### Page Data Objects
-Each page type supports a `data` object for structured content:
+Each `ritual` page requires both the ritual ID and a translation key base for the
+title:
 ```json
 {
   "type": "ritual",
-  "content": "Ritual Name", 
-  "data": {
-    "circle_size": 3,
-    "components": [...],
-    "description": "What this ritual does"
-  }
+  "ritual": "eidolon:crystallization",
+  "text": "eidolonunchained.codex.page.crystal_ritual"
 }
 ```
 


### PR DESCRIPTION
## Summary
- Require a translation key for ritual pages and build them with `TitledRitualPage`
- Document new `text` field for ritual pages in reference, tutorial and datapack README

## Testing
- `./gradlew test` *(fails: cannot find symbol getString in EidolonCodexIntegration.java)*

------
https://chatgpt.com/codex/tasks/task_e_68a77f4ac820832791f9dc15adc5a5f0