### PR TITLE
docs: clarify list page requires altar entries

### DIFF
--- a/docs/codex/reference.md
+++ b/docs/codex/reference.md
@@ -47,11 +47,14 @@ Displays a paragraph of text.
 ```
 {
   "type": "list",
-  "content": "New Features",
-  "data": { "items": ["Advanced Soul Manipulation", "Dimensional Rift Magic"] }
+  "text": "eidolon.codex.altar_overview",
+  "entries": [
+    { "item": "minecraft:gold_block", "text": "Gold Block" },
+    { "item": "minecraft:lapis_block", "text": "Lapis Block" }
+  ]
 }
 ```
-Shows a bullet list of strings.
+Displays a list of items and shows each one's altar power and capacity based on its `AltarEntry`.
 
 ### `crafting`
 ```


### PR DESCRIPTION
## Summary
- Document that `list` codex pages must specify item entries and display each item's altar power and capacity

## Testing
- `./gradlew build` *(fails: cannot find symbol getString in EidolonCodexIntegration.java:97)*

------
https://chatgpt.com/codex/tasks/task_e_68a77f56c5108327ac16038fd5537649