### PR TITLE
refactor: externalize codex entry text

### DIFF
--- a/src/main/resources/assets/eidolonunchained/lang/en_us.json
+++ b/src/main/resources/assets/eidolonunchained/lang/en_us.json
@@ -121,6 +121,13 @@
   "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.purification_effects": "Purification Effects: Active sacred signs cleanse nearby areas of corruption and negative energy. Undead creatures suffer damage when approaching these blessed inscriptions.",
   "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.protective_properties": "Protective Properties: Sacred signs create auras of divine protection that strengthen allies and weaken enemies aligned with darkness. These effects are most powerful during daylight hours and holy celebrations.",
 
+  "eidolonunchained.codex.entry.warded_mail.protective_magic.title": "Protective Magic",
+  "eidolonunchained.codex.entry.warded_mail.protective_magic": "Warded mail is enchanted armor that protects the wearer from magical harm.",
+  "eidolonunchained.codex.entry.warded_mail.chainmail_properties.title": "Chainmail Properties",
+  "eidolonunchained.codex.entry.warded_mail.chainmail_properties": "Chainmail reinforced with magical wards offers superior protection.",
+  "eidolonunchained.codex.entry.warded_mail.crafting_warded_mail.title": "Crafting Warded Mail",
+  "eidolonunchained.codex.entry.warded_mail.crafting_warded_mail": "Crafting warded mail requires rare materials and precise technique.",
+
   "eidolonunchained.codex.entry.shadow_manipulation.title": "Shadow Manipulation",
   "eidolonunchained.codex.entry.shadow_manipulation.intro": "Shadow manipulation is an advanced magical technique that allows practitioners to bend darkness to their will. This ancient art requires both mental discipline and a deep understanding of the void.",
   "eidolonunchained.codex.entry.shadow_manipulation.shadow_crystal": "The Shadow Crystal serves as a focus for shadow-based spells. Its dark surface seems to absorb light itself.",

--- a/src/main/resources/data/eidolonunchained/codex_entries/advanced_monsters.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/advanced_monsters.json
@@ -2,28 +2,28 @@
   "target_chapter": "eidolon:monsters",
   "pages": [
     {
-  "type": "title",
-  "text": "Advanced Monsters"
+      "type": "title",
+      "text": "eidolonunchained.codex.entry.advanced_monsters.title"
     },
     {
       "type": "entity",
       "entity": "eidolon:necromancer"
     },
     {
-  "type": "text",
-  "text": "Necromancers are powerful sorcerers who command the dead and wield forbidden magics."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.advanced_monsters.necromancer"
     },
     {
       "type": "entity", 
       "entity": "eidolon:wraith"
     },
     {
-  "type": "text",
-  "text": "Wraiths are spectral entities, feared for their ability to drain life and pass through solid matter."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.advanced_monsters.wraith"
     },
     {
-  "type": "text",
-  "text": "Advanced monsters exhibit unique behaviors and abilities that challenge even experienced adventurers."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.advanced_monsters.behavior"
     }
   ]
 }

--- a/src/main/resources/data/eidolonunchained/codex_entries/advanced_summoning.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/advanced_summoning.json
@@ -2,28 +2,28 @@
   "target_chapter": "eidolon:summon_ritual",
   "pages": [
     {
-  "type": "title", 
-  "text": "Advanced Summoning"
+      "type": "title",
+      "text": "eidolonunchained.codex.entry.advanced_summoning.title"
     },
     {
-  "type": "text",
-  "text": "Summoning protocols are the foundation of advanced conjuration. Mastery of these allows for more complex and stable summons."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.advanced_summoning.protocols"
     },
     {
-  "type": "text",
-  "text": "Timing is critical in advanced summoning. The correct moment can mean the difference between success and disaster."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.advanced_summoning.timing"
     },
     {
       "type": "entity",
       "entity": "eidolon:wraith"
     },
     {
-  "type": "text",
-  "text": "A bound wraith is a powerful entity that can be controlled by experienced summoners."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.advanced_summoning.bound_wraith"
     },
     {
-  "type": "text",
-  "text": "Manifestation is the final stage, where the summoned entity takes physical form in the world."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.advanced_summoning.manifestation"
     }
   ]
 }

--- a/src/main/resources/data/eidolonunchained/codex_entries/artifice/arcane_gold.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/artifice/arcane_gold.json
@@ -1,31 +1,31 @@
 {
   "target_chapter": "eidolon:arcane_gold",
-  "title": "Advanced Arcane Gold Techniques",
-  "description": "Discover advanced methods for working with arcane gold and unlocking its full potential.",
+  "title": "eidolonunchained.codex.entry.arcane_gold.advanced_techniques.title",
+  "description": "eidolonunchained.codex.entry.arcane_gold.advanced_techniques.description",
   "icon": {
     "item": "eidolon:arcane_gold_ingot",
     "count": 1
   },
   "pages": [
     {
-  "type": "text",
-  "text": "Arcane gold is a rare and powerful material, prized for its magical properties."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.arcane_gold.advanced_techniques.introduction"
     },
     {
       "type": "crafting",
       "item": "eidolon:arcane_gold_ingot"
     },
     {
-  "type": "text",
-  "text": "Enhanced properties of arcane gold make it ideal for crafting potent artifacts."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.arcane_gold.advanced_techniques.enhanced_properties"
     },
     {
       "type": "crucible",
       "recipe": "eidolon:arcane_gold_ingot"
     },
     {
-  "type": "text",
-  "text": "Alchemical refinement can further increase the power of arcane gold."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.arcane_gold.advanced_techniques.alchemical_refinement"
     }
   ],
   "prerequisites": []

--- a/src/main/resources/data/eidolonunchained/codex_entries/artifice/void_amulet.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/artifice/void_amulet.json
@@ -1,31 +1,31 @@
 {
   "target_chapter": "eidolon:void_amulet",
-  "title": "Void Amulet Mastery", 
-  "description": "Master the secrets of the void amulet and its dimensional powers.",
+  "title": "eidolonunchained.codex.entry.void_amulet.mastery.title",
+  "description": "eidolonunchained.codex.entry.void_amulet.mastery.description",
   "icon": {
     "item": "eidolon:void_amulet",
     "count": 1
   },
   "pages": [
     {
-  "type": "text",
-  "text": "The void amulet is a powerful artifact that manipulates dimensional energies."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.void_amulet.mastery.introduction"
     },
     {
       "type": "crafting",
       "item": "eidolon:void_amulet"
     },
     {
-  "type": "text",
-  "text": "Understanding the fundamentals of void energy is essential for safe use."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.void_amulet.mastery.void_fundamentals"
     },
     {
-  "type": "text",
-  "text": "Advanced techniques allow the user to bend space and traverse dimensions."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.void_amulet.mastery.advanced_techniques"
     },
     {
-  "type": "text",
-  "text": "Dimensional risks are inherent; improper use can have catastrophic consequences."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.void_amulet.mastery.dimensional_risks"
     }
   ],
   "prerequisites": []

--- a/src/main/resources/data/eidolonunchained/codex_entries/crystal_rituals.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/crystal_rituals.json
@@ -2,28 +2,28 @@
   "target_chapter": "eidolon:crystal_ritual",
   "pages": [
     {
-  "type": "title",
-  "text": "Crystal Rituals"
+      "type": "title",
+      "text": "eidolonunchained.codex.entry.crystal_rituals.title"
     },
     {
-  "type": "text",
-  "text": "Placement of crystals is crucial for the success of the ritual."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.crystal_rituals.placement"
     },
     {
       "type": "crafting",
       "recipe": "eidolon:arcane_gold_ingot"
     },
     {
-  "type": "text",
-  "text": "Resonance between crystals amplifies magical effects."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.crystal_rituals.resonance"
     },
     {
-  "type": "text",
-  "text": "Different types of crystals produce different magical outcomes."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.crystal_rituals.types"
     },
     {
-  "type": "text",
-  "text": "Advanced rituals require rare crystals and precise arrangements."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.crystal_rituals.advanced"
     }
   ]
 }

--- a/src/main/resources/data/eidolonunchained/codex_entries/equipment/warded_mail.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/equipment/warded_mail.json
@@ -2,20 +2,20 @@
   "target_chapter": "eidolon:warded_mail",
   "pages": [
     {
-  "type": "text",
-  "title": "Protective Magic",
-  "text": "Warded mail is enchanted armor that protects the wearer from magical harm."
+      "type": "text",
+      "title": "eidolonunchained.codex.entry.warded_mail.protective_magic.title",
+      "text": "eidolonunchained.codex.entry.warded_mail.protective_magic"
     },
     {
-  "type": "item_showcase",
-  "title": "Chainmail Properties",
-  "item": "eidolon:warped_sprouts",
-  "text": "Chainmail reinforced with magical wards offers superior protection."
+      "type": "item_showcase",
+      "title": "eidolonunchained.codex.entry.warded_mail.chainmail_properties.title",
+      "item": "eidolon:warped_sprouts",
+      "text": "eidolonunchained.codex.entry.warded_mail.chainmail_properties"
     },
     {
-  "type": "crafting",
-  "title": "Crafting Warded Mail",
-  "recipe": {
+      "type": "crafting",
+      "title": "eidolonunchained.codex.entry.warded_mail.crafting_warded_mail.title",
+      "recipe": {
         "type": "minecraft:crafting_shaped",
         "pattern": [
           "SAS",
@@ -32,7 +32,7 @@
           "count": 1
         }
       },
-  "text": "Crafting warded mail requires rare materials and precise technique."
+      "text": "eidolonunchained.codex.entry.warded_mail.crafting_warded_mail"
     }
   ]
 }

--- a/src/main/resources/data/eidolonunchained/codex_entries/nature/monsters_advanced_studies.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/nature/monsters_advanced_studies.json
@@ -1,7 +1,7 @@
 {
   "target_chapter": "eidolon:monsters",
-  "title": "Advanced Monster Studies",
-  "description": "A deeper look into the abilities and behaviors of advanced monsters.",
+  "title": "eidolonunchained.codex.entry.monsters.advanced_studies.title",
+  "description": "eidolonunchained.codex.entry.monsters.advanced_studies.description",
   "icon": {
     "item": "eidolon:necromancer_spawn_egg",
     "count": 1
@@ -9,15 +9,15 @@
   "pages": [
     {
       "type": "text",
-  "text": "Advanced monster studies reveal the secrets behind their formidable powers."
+      "text": "eidolonunchained.codex.entry.monsters.advanced_studies.introduction"
     },
     {
       "type": "entity",
       "entity": "eidolon:necromancer"
     },
     {
-      "type": "text", 
-  "text": "Necromancers use forbidden rituals to control the dead and unleash dark magic."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.monsters.advanced_studies.necromancer_details"
     },
     {
       "type": "entity",
@@ -25,11 +25,11 @@
     },
     {
       "type": "text",
-  "text": "Wraiths are spirits of vengeance, haunting the living with chilling attacks."
+      "text": "eidolonunchained.codex.entry.monsters.advanced_studies.wraith_details"
     },
     {
       "type": "text",
-  "text": "Each advanced monster has unique behavior patterns that must be studied to be overcome."
+      "text": "eidolonunchained.codex.entry.monsters.advanced_studies.behavior_patterns"
     }
   ],
   "prerequisites": []

--- a/src/main/resources/data/eidolonunchained/codex_entries/nature/monsters_rare_variants.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/nature/monsters_rare_variants.json
@@ -1,7 +1,7 @@
 {
   "target_chapter": "eidolon:monsters",
-  "title": "Rare Monster Variants",
-  "description": "Some monsters possess rare variants with unique abilities and appearances.", 
+  "title": "eidolonunchained.codex.entry.monsters.rare_variants.title",
+  "description": "eidolonunchained.codex.entry.monsters.rare_variants.description",
   "icon": {
     "item": "eidolon:wraith_spawn_egg",
     "count": 1
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "text",
-  "text": "Rare monster variants are seldom seen, but pose a significant threat to the unprepared."
+      "text": "eidolonunchained.codex.entry.monsters.rare_variants.introduction"
     },
     {
       "type": "entity",
@@ -17,7 +17,7 @@
     },
     {
       "type": "text",
-  "text": "Shadow Wraiths are elusive and deadly, striking from the darkness."
+      "text": "eidolonunchained.codex.entry.monsters.rare_variants.shadow_wraiths"
     },
     {
       "type": "entity", 
@@ -25,11 +25,11 @@
     },
     {
       "type": "text",
-  "text": "Frost Skeletons are imbued with chilling power, freezing their foes."
+      "text": "eidolonunchained.codex.entry.monsters.rare_variants.frost_skeleton"
     },
     {
       "type": "text",
-  "text": "Frost Skeletons can slow and weaken those they attack, making them especially dangerous."
+      "text": "eidolonunchained.codex.entry.monsters.rare_variants.frost_details"
     }
   ],
   "prerequisites": []

--- a/src/main/resources/data/eidolonunchained/codex_entries/rare_monsters.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/rare_monsters.json
@@ -2,24 +2,24 @@
   "target_chapter": "eidolon:monsters",
   "pages": [
     {
-  "type": "title",
-  "text": "Rare Monsters"
+      "type": "title",
+      "text": "eidolonunchained.codex.entry.rare_monsters.title"
     },
     {
-  "type": "text",
-  "text": "Shadow Wraiths are elusive and dangerous entities that haunt the darkest corners of the world."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.rare_monsters.shadow_wraiths"
     },
     {
       "type": "entity",
       "entity": "minecraft:stray"
     },
     {
-  "type": "text",
-  "text": "Frost Skeletons are rare undead creatures found in the coldest regions."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.rare_monsters.frost_skeleton"
     },
     {
-  "type": "text",
-  "text": "These skeletons are imbued with icy power, making them formidable opponents."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.rare_monsters.frost_details"
     }
   ]
 }

--- a/src/main/resources/data/eidolonunchained/codex_entries/rituals/crystal_ritual.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/rituals/crystal_ritual.json
@@ -1,31 +1,31 @@
 {
   "target_chapter": "eidolon:crystal_ritual",
-  "title": "Crystal Ritual Mastery",
-  "description": "Unlock the secrets of crystal rituals and harness their magical potential.",
+  "title": "eidolonunchained.codex.entry.crystal_ritual.mastery.title",
+  "description": "eidolonunchained.codex.entry.crystal_ritual.mastery.description",
   "icon": {
     "item": "eidolon:arcane_gold_ingot",
     "count": 1
   },
   "pages": [
     {
-  "type": "text",
-  "text": "Crystal rituals channel energy through carefully arranged crystals."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.crystal_ritual.mastery.introduction"
     },
     {
       "type": "ritual",
       "ritual": "eidolon:crystallization"
     },
     {
-  "type": "text", 
-  "text": "Placement theory explains how the position of each crystal affects the ritual's outcome."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.crystal_ritual.mastery.placement_theory"
     },
     {
-  "type": "text",
-  "text": "Resonance theory describes the interaction between crystals and magical energy."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.crystal_ritual.mastery.resonance_theory"
     },
     {
-  "type": "text",
-  "text": "Advanced configurations allow for more powerful and complex rituals."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.crystal_ritual.mastery.advanced_configurations"
     }
   ],
   "prerequisites": []

--- a/src/main/resources/data/eidolonunchained/codex_entries/rituals/summon_ritual.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/rituals/summon_ritual.json
@@ -1,39 +1,39 @@
 {
   "target_chapter": "eidolon:summon_ritual",
-  "title": "Advanced Summoning Techniques",
-  "description": "Master the advanced techniques of summoning powerful entities and controlling their manifestation.",
+  "title": "eidolonunchained.codex.entry.summon_ritual.advanced_techniques.title",
+  "description": "eidolonunchained.codex.entry.summon_ritual.advanced_techniques.description",
   "icon": {
     "item": "eidolon:wraith_spawn_egg",
     "count": 1
   },
   "pages": [
     {
-  "type": "text",
-  "text": "Advanced summoning rituals require precise incantations and a deep understanding of magical forces."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.summon_ritual.advanced_techniques.introduction"
     },
     {
       "type": "ritual",
       "ritual": "eidolon:lesser_summoning"
     },
     {
-  "type": "text",
-  "text": "Binding protocols ensure the summoned entity remains under your control."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.summon_ritual.advanced_techniques.binding_protocols"
     },
     {
-  "type": "text",
-  "text": "Timing requirements are strict; a single mistake can lead to disaster."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.summon_ritual.advanced_techniques.timing_requirements"
     },
     {
       "type": "entity",
       "entity": "eidolon:wraith"
     },
     {
-  "type": "text",
-  "text": "A bound wraith is a powerful servant, but only the most skilled can maintain control."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.summon_ritual.advanced_techniques.bound_wraith_details"
     },
     {
-  "type": "text",
-  "text": "Manifestation properties determine how the entity appears and interacts with the world."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.summon_ritual.advanced_techniques.manifestation_properties"
     }
   ],
   "prerequisites": []

--- a/src/main/resources/data/eidolonunchained/codex_entries/signs/sacred_sign.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/signs/sacred_sign.json
@@ -1,7 +1,7 @@
 {
   "target_chapter": "eidolon:sacred_sign",
-  "title": "Divine Inscriptions",
-  "description": "The sacred sign holds the power of divine protection and blessing.",
+  "title": "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.title",
+  "description": "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.description",
   "icon": {
     "item": "eidolon:holy_symbol",
     "count": 1
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "text",
-  "text": "Divine inscriptions are ancient symbols used to invoke the favor and protection of higher powers."
+      "text": "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.introduction"
     },
     {
       "type": "crafting",
@@ -17,15 +17,15 @@
     },
     {
       "type": "text",
-  "text": "Blessed materials are required to craft and empower the sacred sign."
+      "text": "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.blessed_materials"
     },
     {
       "type": "text",
-  "text": "Purification effects cleanse the bearer of negative influences."
+      "text": "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.purification_effects"
     },
     {
       "type": "text",
-  "text": "The sacred sign grants powerful protective properties against dark magic."
+      "text": "eidolonunchained.codex.entry.sacred_sign.divine_inscriptions.protective_properties"
     }
   ],
   "prerequisites": []

--- a/src/main/resources/data/eidolonunchained/codex_entries/signs/wicked_sign.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/signs/wicked_sign.json
@@ -1,7 +1,7 @@
 {
   "target_chapter": "eidolon:wicked_sign",
-  "title": "Advanced Applications of the Wicked Sign",
-  "description": "The wicked sign is a symbol of forbidden power, used in advanced magical practices.",
+  "title": "eidolonunchained.codex.entry.wicked_sign.advanced_applications.title",
+  "description": "eidolonunchained.codex.entry.wicked_sign.advanced_applications.description",
   "icon": {
     "item": "eidolon:dark_ink",
     "count": 1
@@ -9,7 +9,7 @@
   "pages": [
     {
       "type": "text",
-  "text": "The wicked sign allows practitioners to tap into dark energies for powerful effects."
+      "text": "eidolonunchained.codex.entry.wicked_sign.advanced_applications.introduction"
     },
     {
       "type": "crafting", 
@@ -17,15 +17,15 @@
     },
     {
       "type": "text",
-  "text": "Ink preparation is crucial for inscribing the wicked sign. Only the purest dark ink will suffice."
+      "text": "eidolonunchained.codex.entry.wicked_sign.advanced_applications.ink_preparation"
     },
     {
       "type": "text",
-  "text": "Sign placement determines the effectiveness and safety of the wicked sign's magic."
+      "text": "eidolonunchained.codex.entry.wicked_sign.advanced_applications.sign_placement"
     },
     {
       "type": "text",
-  "text": "Dark energies can be harnessed through the wicked sign, but must be controlled with care."
+      "text": "eidolonunchained.codex.entry.wicked_sign.advanced_applications.dark_energies"
     }
   ],
   "prerequisites": []

--- a/src/main/resources/data/eidolonunchained/codex_entries/void_mastery.json
+++ b/src/main/resources/data/eidolonunchained/codex_entries/void_mastery.json
@@ -2,20 +2,20 @@
   "target_chapter": "eidolon:void_amulet",
   "pages": [
     {
-  "type": "title",
-  "text": "Void Mastery"
+      "type": "title",
+      "text": "eidolonunchained.codex.entry.void_mastery.title"
     },
     {
-  "type": "text", 
-  "text": "The fundamentals of void mastery involve understanding the nature of emptiness and the flow of magical energy."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.void_mastery.fundamentals"
     },
     {
-  "type": "text",
-  "text": "Advanced void mastery allows the practitioner to manipulate space and reality itself."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.void_mastery.advanced"
     },
     {
-  "type": "text",
-  "text": "The risks of void magic are great; improper use can lead to catastrophic consequences."
+      "type": "text",
+      "text": "eidolonunchained.codex.entry.void_mastery.risks"
     }
   ]
 }


### PR DESCRIPTION
## Summary
- switch codex entry pages to use localization keys instead of inline strings
- localize warded mail codex entry

## Testing
- `./gradlew build` *(fails: cannot find symbol getString in EidolonCodexIntegration.java)*

------
https://chatgpt.com/codex/tasks/task_e_68a7808bb0c88327b340abe181d0f081