### PR TITLE
docs: reintroduce ritual page type

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,10 @@ Create JSON files in `src/main/resources/data/eidolonunchained/codex_entries/`:
     {
       "type": "crafting",
       "recipe": "eidolon:arcane_gold_ingot"
+    },
+    {
+      "type": "ritual",
+      "ritual": "eidolon:summon_wraith"
     }
   ]
 }
@@ -116,7 +120,8 @@ Available page types:
 - **`text`**: Plain text content
 - **`entity`**: Displays an entity with information
 - **`crafting`**: Shows a crafting recipe
-- **`ritual`**: Displays ritual information
+- **`ritual`**: Shows the full ritual layout from a ritual ID
+- **`ritual_recipe`**: Links to a ritual by ID without showing the layout
 
 #### 5. Translation Best Practices
 - Use consistent naming: `eidolonunchained.codex.entry.[entry_name].[section]`

--- a/docs/codex/reference.md
+++ b/docs/codex/reference.md
@@ -87,23 +87,9 @@ Specialized recipe page for crucible crafting.
 
 ### `ritual`
 ```
-{
-  "type": "ritual",
-  "content": "Greater Summoning Circle",
-  "data": {
-    "circle_size": 5,
-    "participants": 3,
-    "components": [
-      {"item": "minecraft:bell", "count": 1},
-      {"item": "minecraft:soul_sand", "count": 32},
-      {"item": "minecraft:wither_skeleton_skull", "count": 3},
-      {"item": "minecraft:nether_star", "count": 1}
-    ],
-    "description": "Summons a powerful ally to aid the community"
-  }
-}
+{ "type": "ritual", "ritual": "<id>" }
 ```
-Shows a top‑down ritual circle with components.
+Displays the full ritual layout for the given ritual ID.
 
 ### `workbench`
 ```
@@ -133,7 +119,9 @@ Links to an existing crafting recipe ID.
 ```
 { "type": "ritual_recipe", "ritual": "eidolonunchained:shadow_bind", "text": "The Shadow Bind ritual allows you to temporarily merge with your own shadow." }
 ```
-References a predefined ritual by ID.
+References a predefined ritual by ID without displaying the layout.
+
+Use `ritual` when you need to show the full ritual circle. Use `ritual_recipe` for quick references to an existing ritual.
 
 ### `image`
 ```

--- a/docs/misc/system_summary.md
+++ b/docs/misc/system_summary.md
@@ -6,7 +6,9 @@ The codex extension system lets datapacks add custom knowledge entries to Eidolo
 ## Current Metrics
 - **Codex entries**: 56 JSON files loaded from `data/eidolonunchained/codex_entries` and `data/eidolonunchained/codex`.
 - **Chapters**: Content spans 10 chapters (8 base Eidolon chapters plus 2 custom mod chapters; a third custom chapter is available for future use).
-- **Supported page types**: 9 – `text`, `title`, `entity`, `crafting`, `ritual`, `crucible`, `list`, `smelting`, and `workbench`.
+- **Supported page types**: 10 – `text`, `title`, `entity`, `crafting`, `ritual`, `ritual_recipe`, `crucible`, `list`, `smelting`, and `workbench`.
+  - `ritual` shows the full ritual circle using a ritual ID
+  - `ritual_recipe` references a ritual by ID without the circle
 
 ## Example Entry
 ```json


### PR DESCRIPTION
## Summary
- reinsert ritual page type docs and add ritual vs ritual_recipe distinction
- show ritual ID example in codex instructions

## Testing
- `./gradlew build` *(fails: cannot find symbol getString)*

------
https://chatgpt.com/codex/tasks/task_e_68a7808c21f08327b04a0c77847f2205