### PR TITLE
docs: list all supported page types

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,15 +29,15 @@ An addon mod for **Eidolon: Repraised** that expands the mystical world with new
 Comprehensive guides live in the [docs/](docs/) directory:
 
 - [Documentation Index](docs/README.md)
-- [Complete System Summary](docs/COMPLETE_SYSTEM_SUMMARY.md)
-- [Datapack Overview](docs/datapack_overview.md)
-- [Datapack Structure](docs/DATAPACK_STRUCTURE.md)
-- [Research Conditions](docs/RESEARCH_CONDITIONS.md)
-- [Research Entries](docs/research_entries.md)
-- [Codex Reference](docs/codex_reference.md)
-- [Codex Tutorial](docs/codex_tutorial.md)
-- [Best Practices](docs/best_practices.md)
-- [UI Customization](docs/ui_customization.md)
+- [Complete System Summary](docs/misc/system_summary.md)
+- [Datapack Overview](docs/datapack/overview.md)
+- [Datapack Structure](docs/datapack/structure.md)
+- [Research Conditions](docs/research/condition_types.md)
+- [Research Entries](docs/research/entry_reference.md)
+- [Codex Reference](docs/codex/reference.md)
+- [Codex Tutorial](docs/codex/tutorial.md)
+- [Best Practices](docs/datapack/best_practices.md)
+- [UI Customization](docs/misc/ui_texture_customization.md)
 - [Example Complete Codex Entry](docs/EXAMPLE_COMPLETE_CODEX_ENTRY.json)
 
 ## Dependencies
@@ -60,7 +60,7 @@ This mod requires the following mods to function:
 
 ## Codex Development Guide
 
-For a step-by-step tutorial see [Codex Tutorial](docs/codex_tutorial.md). For a comprehensive reference see [Codex Reference](docs/codex_reference.md).
+For a step-by-step tutorial see [Codex Tutorial](docs/codex/tutorial.md). For a comprehensive reference see [Codex Reference](docs/codex/reference.md).
 
 ### Creating New Codex Entries
 
@@ -111,12 +111,16 @@ The TitlePage system automatically handles title generation:
 This means each title page displays both the title and introductory content together.
 
 #### 4. Page Types
-Available page types:
-- **`title`**: Creates a page with both title and content
+Available page types (9 total):
 - **`text`**: Plain text content
+- **`title`**: Creates a page with both title and content
 - **`entity`**: Displays an entity with information
 - **`crafting`**: Shows a crafting recipe
 - **`ritual`**: Displays ritual information
+- **`crucible`**: Shows a crucible recipe
+- **`list`**: Displays a bullet list of items
+- **`smelting`**: Shows a furnace recipe
+- **`workbench`**: Displays an Eidolon workbench recipe
 
 #### 5. Translation Best Practices
 - Use consistent naming: `eidolonunchained.codex.entry.[entry_name].[section]`

--- a/docs/misc/system_summary.md
+++ b/docs/misc/system_summary.md
@@ -6,7 +6,7 @@ The codex extension system lets datapacks add custom knowledge entries to Eidolo
 ## Current Metrics
 - **Codex entries**: 56 JSON files loaded from `data/eidolonunchained/codex_entries` and `data/eidolonunchained/codex`.
 - **Chapters**: Content spans 10 chapters (8 base Eidolon chapters plus 2 custom mod chapters; a third custom chapter is available for future use).
-- **Supported page types**: 9 – `text`, `title`, `entity`, `crafting`, `ritual`, `crucible`, `list`, `smelting`, and `workbench`.
+- **Supported page types**: 9 – `text`, `title`, `entity`, `crafting`, `ritual`, `crucible`, `list`, `smelting`, `workbench`.
 
 ## Example Entry
 ```json
@@ -27,12 +27,12 @@ The codex extension system lets datapacks add custom knowledge entries to Eidolo
 
 ## Further Documentation
 - [Documentation Index](../README.md)
-- [Datapack Overview](../datapack_overview.md)
-- [Datapack Structure](../DATAPACK_STRUCTURE.md)
-- [Research Conditions](../RESEARCH_CONDITIONS.md)
-- [Research Entries](../research_entries.md)
-- [Codex Reference](../codex_reference.md)
-- [Codex Tutorial](../codex_tutorial.md)
-- [Best Practices](../best_practices.md)
-- [UI Customization](../ui_customization.md)
+- [Datapack Overview](../datapack/overview.md)
+- [Datapack Structure](../datapack/structure.md)
+- [Research Conditions](../research/condition_types.md)
+- [Research Entries](../research/entry_reference.md)
+- [Codex Reference](../codex/reference.md)
+- [Codex Tutorial](../codex/tutorial.md)
+- [Best Practices](../datapack/best_practices.md)
+- [UI Customization](ui_texture_customization.md)
 - [Example Complete Codex Entry](../EXAMPLE_COMPLETE_CODEX_ENTRY.json)


### PR DESCRIPTION
## Summary
- list all nine codex page types including ritual
- fix broken documentation links to datapack and research guides

## Testing
- `./gradlew test` *(fails: cannot find symbol in EidolonCodexIntegration.java)*

------
https://chatgpt.com/codex/tasks/task_e_68a7808db04483279db16ab0ad2d1371