### PR TITLE
Port codex defaults to JSON and load alongside datapacks

### DIFF
--- a/src/main/resources/data/eidolon/codex_chapters/brazier.json
+++ b/src/main/resources/data/eidolon/codex_chapters/brazier.json
@@ -1,0 +1,4 @@
+{
+  "title": "eidolon.codex.chapter.brazier",
+  "icon": "eidolon:brazier"
+}

--- a/src/main/resources/data/eidolon/codex_chapters/monsters.json
+++ b/src/main/resources/data/eidolon/codex_chapters/monsters.json
@@ -1,0 +1,4 @@
+{
+  "title": "eidolon.codex.chapter.monsters",
+  "icon": "eidolon:tattered_cloth"
+}

--- a/src/main/resources/data/eidolon/codex_entries/brazier.json
+++ b/src/main/resources/data/eidolon/codex_entries/brazier.json
@@ -1,0 +1,8 @@
+{
+  "target_chapter": "eidolon:brazier",
+  "pages": [
+    { "type": "title", "text": "eidolon.codex.page.brazier.0" },
+    { "type": "text", "text": "eidolon.codex.page.brazier.1" },
+    { "type": "crafting", "item": "eidolon:brazier" }
+  ]
+}

--- a/src/main/resources/data/eidolon/codex_entries/monsters.json
+++ b/src/main/resources/data/eidolon/codex_entries/monsters.json
@@ -1,0 +1,15 @@
+{
+  "target_chapter": "eidolon:monsters",
+  "pages": [
+    { "type": "title", "text": "eidolon.codex.page.monsters.zombie_brute" },
+    { "type": "entity", "entity": "eidolon:zombie_brute" },
+    { "type": "title", "text": "eidolon.codex.page.monsters.wraith" },
+    { "type": "entity", "entity": "eidolon:wraith" },
+    { "type": "title", "text": "eidolon.codex.page.monsters.chilled" },
+    { "type": "text", "text": "" },
+    { "type": "entity", "entity": "eidolon:giant_skeleton" },
+    { "type": "title", "text": "eidolon.codex.page.monsters.giant_skeleton" },
+    { "type": "entity", "entity": "eidolon:necromancer" },
+    { "type": "title", "text": "eidolon.codex.page.monsters.necromancer" }
+  ]
+}


### PR DESCRIPTION
## Summary
- replace hardcoded codex data with JSON chapters and entries for monsters and brazier
- teach `CodexDataManager` to scan resource packs directly so builtin data loads with datapacks

## Testing
- `./gradlew build` *(fails: cannot find symbol CodexGui in EidolonPageConverter)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a819190c8327ae0e18e0f5a4450d