### PR TITLE
Add safe reflection helpers with fallback logging

### DIFF
--- a/docs/REFLECTION_TARGETS.md
+++ b/docs/REFLECTION_TARGETS.md
@@ -1,0 +1,15 @@
+# Reflection Targets
+
+This mod currently uses reflection to access internal classes and fields of Eidolon Repraised
+(version 0.3.8.15). Update the paths below if upstream names change.
+
+| Purpose | Class Path | Field | Notes |
+|--------|------------|-------|-------|
+| Categories list | `elucent.eidolon.codex.CodexChapters` | `categories` | Replace with official API when available |
+| Category key | `elucent.eidolon.codex.Category` | `key` | Use `Category#getKey()` once exposed |
+| Category index holder | `elucent.eidolon.codex.Category` | `chapter` | Should become public chapter/index accessor |
+| Chapter page list | `elucent.eidolon.codex.Chapter` | `pages` | Replace with public getter when provided |
+| IndexPage entries | `elucent.eidolon.codex.IndexPage` | `entries` | Replace with accessor or builder |
+
+If any of these targets change, adjust the constants in `EidolonCategoryExtension`
+and update this document to reflect the new paths.


### PR DESCRIPTION
## Summary
- Centralize reflection targets and add helper methods for safer `Class.forName` and `Field#setAccessible` usage
- Log missing classes/fields and skip processing gracefully
- Document current internal field paths for easier updates

## Testing
- `./gradlew test` *(fails: cannot find symbol CodexGui in EidolonPageConverter)*

------
https://chatgpt.com/codex/tasks/task_e_68a7a81a31e08327837a66107738fc58