### PR TITLE
Use recipe output for workbench page

### DIFF
--- a/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonPageConverter.java
+++ b/src/main/java/com/bluelotuscoding/eidolonunchained/integration/EidolonPageConverter.java
@@ -29,6 +29,9 @@ import elucent.eidolon.api.spells.Sign;
 import elucent.eidolon.api.spells.Spell;
 import elucent.eidolon.registries.Signs;
 import elucent.eidolon.registries.Spells;
+import elucent.eidolon.recipe.WorktableRecipe;
+import elucent.eidolon.recipe.WorktableRegistry;
+import elucent.eidolon.util.RecipeUtil;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiGraphics;
 import net.minecraft.network.chat.Component;
@@ -36,6 +39,9 @@ import net.minecraft.resources.ResourceLocation;
 import net.minecraft.world.entity.EntityType;
 import net.minecraft.world.item.Item;
 import net.minecraft.world.item.ItemStack;
+import net.minecraft.world.item.crafting.Recipe;
+import net.minecraft.world.item.crafting.RecipeManager;
+import net.minecraft.core.RegistryAccess;
 import net.minecraftforge.registries.ForgeRegistries;
 import net.minecraftforge.api.distmarker.Dist;
 import net.minecraftforge.api.distmarker.OnlyIn;
@@ -588,21 +594,46 @@ public class EidolonPageConverter {
     private static Page createWorkbenchPage(JsonObject pageJson) {
         String itemId = pageJson.has("item") ? pageJson.get("item").getAsString() : "";
         String recipeId = pageJson.has("recipe") ? pageJson.get("recipe").getAsString() : "";
-
-        Item item = null;
+        ItemStack stack = ItemStack.EMPTY;
         if (!itemId.isEmpty()) {
             ResourceLocation itemRes = ResourceLocation.tryParse(itemId);
             if (itemRes != null) {
-                item = ForgeRegistries.ITEMS.getValue(itemRes);
+                Item item = ForgeRegistries.ITEMS.getValue(itemRes);
+                if (item != null) {
+                    stack = new ItemStack(item);
+                }
             }
         } else if (!recipeId.isEmpty()) {
-            ResourceLocation recipeRes = ResourceLocation.tryParse(recipeId);
-            if (recipeRes != null) {
-                item = ForgeRegistries.ITEMS.getValue(recipeRes);
+            stack = getRecipeOutput(recipeId);
+            if (stack.isEmpty()) {
+                ResourceLocation recipeRes = ResourceLocation.tryParse(recipeId);
+                if (recipeRes != null) {
+                    String path = recipeRes.getPath();
+                    int slash = path.lastIndexOf('/');
+                    String base = slash >= 0 ? path.substring(slash + 1) : path;
+                    String namespace = recipeRes.getNamespace();
+                    String[] guesses = {
+                            namespace + ":" + base,
+                            namespace + ":" + base + "_ingot",
+                            namespace + ":" + base + "_gem",
+                            namespace + ":" + base + "_crystal"
+                    };
+                    for (String guess : guesses) {
+                        ResourceLocation guessRes = ResourceLocation.tryParse(guess);
+                        if (guessRes != null) {
+                            Item guessItem = ForgeRegistries.ITEMS.getValue(guessRes);
+                            if (guessItem != null) {
+                                stack = new ItemStack(guessItem);
+                                LOGGER.info("Guessed recipe result item: {} -> {}", recipeId, guess);
+                                break;
+                            }
+                        }
+                    }
+                }
             }
         }
 
-        if (item == null) {
+        if (stack.isEmpty()) {
             LOGGER.warn("Workbench page missing valid item or recipe");
             return createFallbackTextPage(pageJson);
         }
@@ -610,11 +641,39 @@ public class EidolonPageConverter {
         if (!recipeId.isEmpty()) {
             ResourceLocation recipeRes = ResourceLocation.tryParse(recipeId);
             if (recipeRes != null) {
-                return new WorktablePage(new ItemStack(item), recipeRes);
+                return new WorktablePage(stack, recipeRes);
             }
         }
 
-        return new WorktablePage(new ItemStack(item));
+        return new WorktablePage(stack);
+    }
+
+    /**
+     * Attempt to fetch the output ItemStack for a recipe ID.
+     */
+    private static ItemStack getRecipeOutput(String recipeId) {
+        ResourceLocation recipeRes = ResourceLocation.tryParse(recipeId);
+        if (recipeRes == null) return ItemStack.EMPTY;
+
+        RecipeManager manager = RecipeUtil.getRecipeManager();
+        if (manager != null) {
+            Recipe<?> recipe = manager.byKey(recipeRes).orElse(null);
+            if (recipe != null) {
+                try {
+                    ItemStack result = recipe.getResultItem(RegistryAccess.EMPTY);
+                    if (!result.isEmpty()) return result.copy();
+                } catch (Throwable ignored) {
+                }
+            }
+        }
+
+        WorktableRecipe wt = WorktableRegistry.find(recipeRes);
+        if (wt != null) {
+            ItemStack result = wt.getResultItem();
+            if (!result.isEmpty()) return result.copy();
+        }
+
+        return ItemStack.EMPTY;
     }
 
     /**


### PR DESCRIPTION
## Summary
- resolve workbench pages by extracting ItemStacks from recipe results when only a recipe id is provided
- retain heuristic fallbacks for ambiguous recipe lookups and centralize recipe result fetching

## Testing
- `./gradlew build` *(fails: local variables referenced from lambda must be final)*

------
https://chatgpt.com/codex/tasks/task_e_68a7af737bbc83279288770908070456